### PR TITLE
Add states natively to execution monad

### DIFF
--- a/ArchSem/GenPromising.v
+++ b/ArchSem/GenPromising.v
@@ -234,7 +234,6 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
       (** Check if all threads have no outstanding promises *)
       Definition nopromises (ps : t) := fforallb (nopromises_tid ps).
 
-      (* Definition liftSt {St St' E A} (getter : St → St') `{Setter St St' getter} (inner : Exec.t St' E A) : Exec.t St E A. *)
       (** Run on instruction in specific thread by tid *)
       Definition run_tid (tid : fin n) : Exec.t t string () :=
         st ←@{Exec.t t string} mGet;

--- a/ArchSem/GenPromising.v
+++ b/ArchSem/GenPromising.v
@@ -128,6 +128,7 @@ Section PM.
 End PM.
 Arguments t : clear implicits.
 End PromMemory.
+#[export] Typeclasses Transparent PromMemory.t.
 
 (* Partial Promising State *)
 Module PPState.

--- a/ArchSem/GenPromising.v
+++ b/ArchSem/GenPromising.v
@@ -235,19 +235,16 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
       Definition nopromises (ps : t) := fforallb (nopromises_tid ps).
 
       (* Definition liftSt {St St' E A} (getter : St → St') `{Setter St St' getter} (inner : Exec.t St' E A) : Exec.t St E A. *)
-
       (** Run on instruction in specific thread by tid *)
-      Program Definition run_tid (tid : fin n) : Exec.t t string () :=
+      Definition run_tid (tid : fin n) : Exec.t t string () :=
         st ←@{Exec.t t string} mGet;
         let handler := prom.(handler) tid (st.(initmem)) in
         let sem := (isem.(semantic) (istate tid st)) in
         let init := (tstate tid st, st.(events), prom.(iis_init)) in
-        ist ← @Exec.liftSt _ (tState * PromMemory.t mEvent * iis prom)%type _ _
-              (λ st : t, (tstate tid st, events st, (* const_getter *) prom.(iis_init))) _
-              (cinterp handler sem);
+        ist ← Exec.liftSt
+                (tstate tid ×× events ×× const_getter prom.(iis_init))
+                (cinterp handler sem);
         msetv (istate tid) ist.
-        Next Obligation.
-        Admitted.
 
       (** Compute the set of allowed promises by a thread indexed by tid *)
       Definition allowed_promises_tid (st : t) (tid : fin n) :=

--- a/ArchSem/GenPromising.v
+++ b/ArchSem/GenPromising.v
@@ -386,8 +386,7 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
 Definition Promising_to_Modelc {isem : iSem} (prom : BasicExecutablePM)
       (fuel : nat) : Model.c ∅ :=
       fun n (initMs : MState.init n) =>
-        let initPs := PState.from_MState isem prom initMs in
-        initPs |>
+        PState.from_MState isem prom initMs |>
         Model.Res.from_exec
           $ CPState.to_final_MState
           <$> CPState.run isem prom initMs.(MState.termCond) fuel.

--- a/ArchSem/GenPromising.v
+++ b/ArchSem/GenPromising.v
@@ -267,10 +267,9 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
 
       (** Run on instruction in specific thread by tid *)
       Definition run_tid (tid : fin n) : Exec.t t string () :=
-        st ←@{Exec.t t string} mGet;
+        st ← mGet;
         let handler := prom.(handler) tid (st.(initmem)) in
         let sem := (isem.(semantic) (istate tid st)) in
-        let init := (tstate tid st, st.(events), prom.(iis_init)) in
         ist ← Exec.liftSt (PState_PPState tid)
                 (cinterp handler sem);
         msetv (istate tid) ist.
@@ -369,7 +368,7 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
         search but it is obviously correct. If a thread has reached termination
         no progress is made in the thread (either instruction running or
         promises *)
-    (* TODO make if only on bool *)
+    (* TODO: Make if/then/else syntax only work on bool *)
     Definition run_step (fuel : nat) : Exec.t t string () :=
       st ← mGet;
       tid ← mchoose n;
@@ -402,7 +401,7 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
           st ← mGet;
           if dec $ terminated isem prom term st then mret (make_final st _)
           else
-            nextSt ← run_step fuel;
+            run_step fuel;;
             run fuel
       end.
     Solve All Obligations with naive_solver.
@@ -413,13 +412,13 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
 
 
   (** Create a computational model from an ISA model and promising model *)
-Definition Promising_to_Modelc {isem : iSem} (prom : BasicExecutablePM)
+  Definition Promising_to_Modelc {isem : iSem} (prom : BasicExecutablePM)
       (fuel : nat) : Model.c ∅ :=
-      fun n (initMs : MState.init n) =>
-        PState.from_MState isem prom initMs |>
-        Model.Res.from_exec
-          $ CPState.to_final_MState
-          <$> CPState.run isem prom initMs.(MState.termCond) fuel.
+    fun n (initMs : MState.init n) =>
+      PState.from_MState isem prom initMs |>
+      Model.Res.from_exec
+        $ CPState.to_final_MState
+        <$> CPState.run isem prom initMs.(MState.termCond) fuel.
 
     (* TODO state some soundness lemma between Promising_to_Modelnc and
         Promising_Modelc *)

--- a/ArchSem/GenPromising.v
+++ b/ArchSem/GenPromising.v
@@ -384,13 +384,14 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
 
 
   (** Create a computational model from an ISA model and promising model *)
-(* TODO: Definition Promising_to_Modelc {isem : iSem} (prom : BasicExecutablePM)
+Definition Promising_to_Modelc {isem : iSem} (prom : BasicExecutablePM)
       (fuel : nat) : Model.c ∅ :=
       fun n (initMs : MState.init n) =>
         let initPs := PState.from_MState isem prom initMs in
+        initPs |>
         Model.Res.from_exec
           $ CPState.to_final_MState
-          <$> CPState.run isem prom initMs.(MState.termCond) fuel initPs. *)
+          <$> CPState.run isem prom initMs.(MState.termCond) fuel.
 
     (* TODO state some soundness lemma between Promising_to_Modelnc and
         Promising_Modelc *)

--- a/ArchSem/GenPromising.v
+++ b/ArchSem/GenPromising.v
@@ -326,7 +326,7 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
       prom.(promise_select) n tid (initmem st) (tstate tid st) (events st).
 
     (** Take any promising step for that tid and promise it *)
-    Program Definition cpromise_tid (fuel : nat) (tid : fin n)
+    Definition cpromise_tid (fuel : nat) (tid : fin n)
       : Exec.t t string () :=
     λ st,
       let res_st :=
@@ -340,7 +340,7 @@ Module GenPromising (IWA : InterfaceWithArch) (TM : TermModelsT IWA).
         no progress is made in the thread (either instruction running or
         promises *)
     (* TODO make if only on bool *)
-    Program Definition run_step (fuel : nat) : Exec.t t string () :=
+    Definition run_step (fuel : nat) : Exec.t t string () :=
       st ← mGet;
       tid ← mchoose n;
       if terminated_tid isem prom term st tid then mdiscard

--- a/ArchSem/TermModels.v
+++ b/ArchSem/TermModels.v
@@ -281,9 +281,9 @@ Module TermModels (IWA : InterfaceWithArch). (* to be imported *)
       End MR.
       Arguments t : clear implicits.
 
-      Definition from_exec {n} (e : Exec.t string (MState.final n)) :
+      Definition from_exec {St n} (e : Exec.t St string (MState.final n)) (st : St) :
           listset (t ∅ n) :=
-        e |> Exec.to_result_list |$> from_result |> Listset.
+        e st |> Exec.to_result_list |$> snd |$> from_result |> Listset.
 
     End Res.
 

--- a/ArchSem/TermModels.v
+++ b/ArchSem/TermModels.v
@@ -281,7 +281,7 @@ Module TermModels (IWA : InterfaceWithArch). (* to be imported *)
       End MR.
       Arguments t : clear implicits.
 
-      Program Definition from_exec {St n} (e : Exec.t St string (MState.final n)) (st : St) :
+      Definition from_exec {St n} (e : Exec.t St string (MState.final n)) (st : St) :
           listset (t ∅ n) :=
         e st |> Exec.to_stateful_result_list |$> snd |$> from_result |> Listset.
 

--- a/ArchSem/TermModels.v
+++ b/ArchSem/TermModels.v
@@ -281,9 +281,9 @@ Module TermModels (IWA : InterfaceWithArch). (* to be imported *)
       End MR.
       Arguments t : clear implicits.
 
-      Definition from_exec {St n} (e : Exec.t St string (MState.final n)) (st : St) :
+      Program Definition from_exec {St n} (e : Exec.t St string (MState.final n)) (st : St) :
           listset (t ∅ n) :=
-        e st |> Exec.to_result_list |$> snd |$> from_result |> Listset.
+        e st |> Exec.to_stateful_result_list |$> snd |$> from_result |> Listset.
 
     End Res.
 

--- a/ArchSemArm/ArmSeqModel.v
+++ b/ArchSemArm/ArmSeqModel.v
@@ -171,7 +171,7 @@ Definition sequential_modelc (fuel : nat) (isem : iMon ()) : (Model.c ∅) :=
   match n with
   | 1 => λ initSt : MState.init 1,
     {| initSt := initSt; regs := ∅; mem := ∅ |}
-    |> Model.Res.from_exec $ sequential_model_seqmon fuel isem
+    |> Model.Res.from_exec (sequential_model_seqmon fuel isem)
   | _ => λ _, mret (Model.Res.Error "Exptected one thread")
   end.
 

--- a/ArchSemArm/ArmSeqModel.v
+++ b/ArchSemArm/ArmSeqModel.v
@@ -170,11 +170,11 @@ Definition sequential_modelc (fuel : nat) (isem : iMon ()) : (Model.c ∅) :=
   λ n,
   match n with
   | 1 => λ initSt : MState.init 1,
-           Listset
+            Listset
             (sequential_model_seqmon fuel isem {| initSt := initSt; regs := ∅; mem := ∅ |}
-             |> Exec.to_result_list
-             |$> snd
-             |$> Model.Res.from_result)
+              |> Exec.to_stateful_result_list
+              |$> snd
+              |$> Model.Res.from_result)
   | _ => λ _, mret (Model.Res.Error "Exptected one thread")
   end.
 

--- a/ArchSemArm/ArmSeqModel.v
+++ b/ArchSemArm/ArmSeqModel.v
@@ -170,11 +170,8 @@ Definition sequential_modelc (fuel : nat) (isem : iMon ()) : (Model.c ∅) :=
   λ n,
   match n with
   | 1 => λ initSt : MState.init 1,
-            Listset
-            (sequential_model_seqmon fuel isem {| initSt := initSt; regs := ∅; mem := ∅ |}
-              |> Exec.to_stateful_result_list
-              |$> snd
-              |$> Model.Res.from_result)
+    {| initSt := initSt; regs := ∅; mem := ∅ |}
+    |> Model.Res.from_exec $ sequential_model_seqmon fuel isem
   | _ => λ _, mret (Model.Res.Error "Exptected one thread")
   end.
 

--- a/ArchSemArm/ArmSeqModel.v
+++ b/ArchSemArm/ArmSeqModel.v
@@ -64,7 +64,7 @@ Record seq_state := {
 Global Instance eta_seq_state : Settable seq_state :=
   settable! Build_seq_state <initSt;mem;regs>.
 
-Notation seqmon := (stateT seq_state (Exec.t string)).
+Notation seqmon := (Exec.t seq_state string).
 
 Definition read_reg_seq_state (reg : reg) (seqst : seq_state) : reg_type reg:=
   if (seqst.(regs) !! reg) is Some v
@@ -163,14 +163,6 @@ Fixpoint sequential_model_seqmon (fuel : nat) (isem : iMon ())
     else sequential_model_seqmon fuel isem
   else mthrow "Out of fuel".
 
-(** Run the model on given initial MState and an initially blank sequential state.
-    The sequential state gets discarded and only the final state is returned *)
-Definition sequential_model_exec (fuel : nat) (isem : iMon ())
-  (initSt : MState.init 1) : Exec.t string (MState.final 1) :=
-  '(_, fs) ← sequential_model_seqmon fuel isem
-             {| initSt := initSt; regs := ∅; mem := ∅ |};
-  mret fs.
-
 (** Top-level one-threaded sequential model function that takes fuel (guaranteed
     termination) and an instruction monad, and returns a computational set of
     all possible final states. *)
@@ -179,8 +171,9 @@ Definition sequential_modelc (fuel : nat) (isem : iMon ()) : (Model.c ∅) :=
   match n with
   | 1 => λ initSt : MState.init 1,
            Listset
-            (sequential_model_exec fuel isem initSt
+            (sequential_model_seqmon fuel isem {| initSt := initSt; regs := ∅; mem := ∅ |}
              |> Exec.to_result_list
+             |$> snd
              |$> Model.Res.from_result)
   | _ => λ _, mret (Model.Res.Error "Exptected one thread")
   end.

--- a/ArchSemArm/UMPromising.v
+++ b/ArchSemArm/UMPromising.v
@@ -491,7 +491,7 @@ Module IIS.
     iis |> set strict (max v).
 
 End IIS.
-About PPState.t.
+
 (** Runs an outcome. *)
 Definition run_outcome (tid : nat) (initmem : memoryMap) (out : outcome) :
     Exec.t (PPState.t TState.t Msg.t IIS.t) string (eff_ret out) :=
@@ -591,10 +591,10 @@ Definition UMPromising_nocert isem :=
   : relation (TState.t * PromMemory.t Msg.t) :=
   let handler := run_outcome tid initmem in
   λ '(ts, mem) '(ts', mem'),
-  CResult.Ok (E := PPState.t TState.t Msg.t IIS.t) (ts', mem') ∈
-    cinterp handler isem (PPState.Make ts mem IIS.init)
-    |> Exec.to_state_result_list
-    |$> (fmap (M := CResult.result _) (λ '(PPState.Make ts mem iis), (ts, mem))).
+    CResult.Ok (ts', mem') ∈
+      cinterp handler isem (PPState.Make ts mem IIS.init)
+      |> Exec.to_state_result_list
+      |$> (fmap (M := CResult.result _) (λ '(PPState.Make ts mem iis), (ts, mem))).
 
 Definition allowed_promises_cert (isem : iMon ()) tid (initmem : memoryMap)
     (ts : TState.t) (mem : Memory.t) :=

--- a/ArchSemArm/UMPromising.v
+++ b/ArchSemArm/UMPromising.v
@@ -533,8 +533,7 @@ Definition run_outcome (tid : nat) (initmem : memoryMap) (out : outcome) :
       match wr.(WriteReq.access_kind) with
       | AK_explicit eak =>
           mem ← mget PPState.mem;
-          iis ← mget PPState.iis;
-          let vdata := iis.(IIS.strict) in
+          vdata ← mget (IIS.strict ∘ PPState.iis);
           mem ← Exec.liftSt PPState.state (write_mem_xcl tid addr vdata eak mem data);
           msetv PPState.mem mem;;
           mret (inl true)

--- a/ArchSemArm/UMPromising.v
+++ b/ArchSemArm/UMPromising.v
@@ -167,7 +167,7 @@ Module Memory.
 
   (** The promising memory: a list of events *)
   Definition t : Type := t Msg.t.
-  #[global] Typeclasses Transparent t.
+  #[export] Typeclasses Transparent t.
 
   Definition cut_after : nat -> t -> t := @cut_after Msg.t.
   Definition cut_before : nat -> t -> t := @cut_before Msg.t.
@@ -259,6 +259,7 @@ Module Memory.
     end.
 
 End Memory.
+Import (hints) Memory.
 
 Module FwdItem.
    Record t :=

--- a/ArchSemArm/UMPromising.v
+++ b/ArchSemArm/UMPromising.v
@@ -593,8 +593,8 @@ Definition seq_step (isem : iMon ()) (tid : nat) (initmem : memoryMap)
   let handler := run_outcome tid initmem in
   λ '(ts, mem) '(ts', mem'),
     (ts', mem') ∈
-      (PPState.state ×× PPState.mem)
-      <$> (Exec.success_state_list $ cinterp handler isem (PPState.Make ts mem IIS.init)).
+      PPState.state ×× PPState.mem
+        <$> (Exec.success_state_list $ cinterp handler isem (PPState.Make ts mem IIS.init)).
 
 Definition allowed_promises_cert (isem : iMon ()) tid (initmem : memoryMap)
     (ts : TState.t) (mem : Memory.t) :=

--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -1173,7 +1173,7 @@ Definition read_pte (vaddr : view)
   val ← Exec.liftSt snd IIS.TransRes.pop;
   mset fst $ TState.update TState.vspec vpost;;
   mret (vpost, val).
-Print CResult.result.
+
 (** Run a MemRead outcome.
     Returns the new thread state, the vpost of the read and the read value. *)
 Definition run_mem_read (rr : ReadReq.t 8) (init : Memory.initial) :

--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -273,18 +273,22 @@ Module Memory.
     lasts ++ [first].
 
   (** Promise a write and add it at the end of memory *)
-  Definition promise (ev : Ev.t) (mem : t) : view * t :=
-    let nmem := ev :: mem in (List.length nmem, nmem).
+  Definition promise (ev : Ev.t) : Exec.t t string view :=
+    mSet (cons ev);;
+    mem ← mGet;
+    mret (List.length mem).
 
   (** Returns a view among a promise set that correspond to an event. The
       oldest matching view is taken. This is because it can be proven that
       taking a more recent view, will make the previous promises unfulfillable
       and thus the corresponding executions would be discarded. TODO prove it.
       *)
-  Definition fulfill (ev : Ev.t) (prom : list view) (mem : t) : option view :=
+  Definition fulfill (ev : Ev.t) (prom : list view) : Exec.t t string (option view) :=
+    mem ← (mcall (@MGet t));
     prom |> filter (fun t => Some ev =? mem !! t)
          |> reverse
-         |> head.
+         |> head
+         |> mret.
 
   (** Check that the write at the provided timestamp is indeed to that location
       and that no write to that location have been made by any other thread *)
@@ -1090,12 +1094,11 @@ Module IIS.
     #[global] Instance eta : Settable _ :=
       settable! make <time; remaining; invalidation>.
 
-    Definition pop (tr : t) : Exec.t string (bv 64 * t) :=
-      match tr.(remaining) with
-      | h :: tl => mret (h, setv remaining tl tr)
-      | _ => mthrow
-              "Couldn't pop the next PTE: error in translation assumptions"
-      end.
+    Definition pop : Exec.t t string (bv 64) :=
+      remain ← mget remaining;
+      '(h, tl) ← remain |> Exec.error_Nil "Couldn't pop the next PTE: error in translation assumptions";
+      msetv remaining tl;;
+      mret h.
   End TransRes.
 
   Record t :=
@@ -1134,12 +1137,13 @@ Definition read_fwd_view (ak : Explicit_access_kind) (f : FwdItem.t) :=
 (** Performs a memory read at a location with a view and return possible output
     states with the timestamp and value of the read *)
 Definition read_mem_explicit (loc : Loc.t) (vaddr : view)
-  (invalidation_time : nat) (ak : Explicit_access_kind) (ts : TState.t)
-  (init : Memory.initial) (mem : Memory.t)
-  : Exec.t string (TState.t * view * val) :=
+  (invalidation_time : nat) (ak : Explicit_access_kind)
+  (init : Memory.initial)
+  : Exec.t (TState.t * Memory.t) string (view * val) :=
   let acs := ak.(Explicit_access_kind_strength) in
   let acv := ak.(Explicit_access_kind_variety) in
   guard_or "Atomic RMV unsupported" (acv =? AV_atomic_rmw);;
+  ts ← mget fst;
   let vbob := ts.(TState.vdmb) ⊔ ts.(TState.vdsb)
               ⊔ ts.(TState.vcse) ⊔ ts.(TState.vacq)
                 (* Strong Acquire loads are ordered after Release stores *)
@@ -1148,105 +1152,97 @@ Definition read_mem_explicit (loc : Loc.t) (vaddr : view)
   (* We only read after the coherence point, because without mixed-size, this
      is equivalent to reading at vpre and discarding incoherent options *)
   let vread := vpre ⊔ (TState.coh ts loc) in
+  mem ← mget snd;
   '(res, time) ← Exec.Results $ Memory.read loc vread init mem;
   let fwd := TState.fwdb ts loc in
   let read_view :=
     if (fwd.(FwdItem.time) =? time) then read_fwd_view ak fwd else time in
   let vpost := vpre ⊔ read_view in
   guard_discard (vpost <= invalidation_time)%nat;;
-  let ts :=
-    ts |> TState.update_coh loc time
-       |> TState.update TState.vrd vpost
-       |> TState.update TState.vacq (view_if (negb (acs =? AS_normal)) vpost)
-       |> TState.update TState.vspec vaddr
-       |> (if acv =? AV_exclusive then TState.set_xclb (time, vpost) else id)
-  in mret (ts, vpost, res).
+  mset fst $ TState.update_coh loc time;;
+  mset fst $ TState.update TState.vrd vpost;;
+  mset fst $ TState.update TState.vacq (view_if (negb (acs =? AS_normal)) vpost);;
+  mset fst $ TState.update TState.vspec vaddr;;
+  mset fst $ (if acv =? AV_exclusive then TState.set_xclb (time, vpost) else id);;
+  mret (vpost, res).
 
-Definition read_pte (ts : TState.t) (vaddr : view)
-  (tsum : translation) (tres : IIS.TransRes.t)
-  : Exec.t string (TState.t * view * val * IIS.TransRes.t) :=
+Definition read_pte (vaddr : view)
+  (tsum : translation)
+  : Exec.t (TState.t * IIS.TransRes.t) string (view * val) :=
+  tres ← mget snd;
   let vpost := vaddr ⊔ tres.(IIS.TransRes.time) in
-  '(val, tres) ← IIS.TransRes.pop tres;
-  let ts := ts |> TState.update TState.vspec vpost in
-  mret (ts, vpost, val, tres).
-
-
-
+  val ← Exec.liftSt snd IIS.TransRes.pop;
+  mset fst $ TState.update TState.vspec vpost;;
+  mret (vpost, val).
 
 (** Run a MemRead outcome.
     Returns the new thread state, the vpost of the read and the read value. *)
-Definition run_mem_read (rr : ReadReq.t 8) (iis : IIS.t)
-  (ts : TState.t) (init : Memory.initial) (mem : Memory.t)
-  : Exec.t string (TState.t * IIS.t * val) :=
+Definition run_mem_read (rr : ReadReq.t 8) (init : Memory.initial) :
+    Exec.t (TState.t * Memory.t * IIS.t) string val :=
   addr ← Exec.error_none "PA not supported" $ Loc.from_pa rr.(ReadReq.pa);
+  iis ← mget snd;
   let vaddr := iis.(IIS.strict) in
   let va : bv 64 := default (Loc.to_va addr) rr.(ReadReq.va) in
-  let trans_res := iis.(IIS.trs) !! (bv_extract 12 36 va) in
-  let inv :=
-    trans_res |> fmap (fun tr => tr.(IIS.TransRes.invalidation)) |> default (0 % nat)
-  in
   match rr.(ReadReq.access_kind) with
   | AK_explicit eak =>
-      '(ts, view, val) ← read_mem_explicit addr vaddr inv eak ts init mem;
-      let iis := IIS.add view iis in
-      mret (ts, iis, val)
+      trans_res ← mget ((.!! (bv_extract 12 36 va)) ∘ IIS.trs ∘ snd);
+      let inv :=
+        trans_res |> fmap (fun tr => tr.(IIS.TransRes.invalidation)) |> default (0 % nat)
+      in
+      '(view, val) ← Exec.liftSt fst $ read_mem_explicit addr vaddr inv eak init;
+      mset snd $ IIS.add view;;
+      mret val
   | AK_ttw () =>
-      tres ← Exec.error_none "TTW read before translation start" trans_res;
-      '(ts, view, val, tres) ←
-        read_pte ts vaddr rr.(ReadReq.translation) tres;
-      let iis :=
-        iis |> IIS.add view
-          |> IIS.set_trs (bv_extract 12 36 va) tres
-      in mret (ts, iis, val)
+      '(view, val) ← Exec.partial_liftSt
+                      (λ '(ts,mem,iis), if iis.(IIS.trs) !! (bv_extract 12 36 va) then True else False)
+                      "TTW read before translation start"
+                      (λ '(ts,mem,iis) H_some, (ts, unfold_if_Some H_some))
+                      (λ '(ts,tres) '(_,mem,iis), (ts, mem, IIS.set_trs (bv_extract 12 36 va) tres iis))
+                      $ read_pte vaddr rr.(ReadReq.translation);
+      mset snd $ IIS.add view;;
+      mret val
   | AK_ifetch () => mthrow "8 bytes ifetch ???"
   | _ => mthrow "Only ifetch, ttw and explicit accesses supported"
   end.
 
-
-Definition run_mem_read4 (rr : ReadReq.t 4) (iis : IIS.t)
-  (ts : TState.t) (init : Memory.initial) (mem : Memory.t)
-  : Exec.t string (bv 32) :=
-  let addr := rr.(ReadReq.pa) in
-  let aligned_addr := bv_unset_bit 2 addr in
-  let bit2 := addr |> bv_get_bit 2 in
-  loc ← Exec.error_none "PA not supported" $ Loc.from_pa aligned_addr;
+Definition run_mem_read4 (rr : ReadReq.t 4) (init : Memory.initial) :
+    Exec.t Memory.t string (bv 32) :=
   match rr.(ReadReq.access_kind) with
   | AK_ifetch () =>
+      let addr := rr.(ReadReq.pa) in
+      let aligned_addr := bv_unset_bit 2 addr in
+      let bit2 := bv_get_bit 2 addr in
+      loc ← Exec.error_none "PA not supported" $ Loc.from_pa aligned_addr;
+      mem ← mGet;
       block ← Exec.error_none "Modified instruction memory"
                               (Memory.read_initial loc init mem);
-      (if bit2 then bv_extract 32 32 else bv_extract 0 32) block
-        |> mret
+      mret $ (if bit2 then bv_extract 32 32 else bv_extract 0 32) block
   | _ => mthrow "4 bytes accesses unsupported (except ifetch)"
   end.
-
 
 
 (** Performs a memory write for a thread tid at a location loc with view
     vaddr and vdata. Return the new state.
 
     This may mutate memory if no existing promise can be fullfilled *)
-Definition write_mem (tid : nat) (loc : Loc.t) (viio : view)
-           (acs : Access_strength) (ts : TState.t) (mem : Memory.t)
-           (data : val) : Exec.t string (TState.t * Memory.t * view):=
+Definition write_mem (tid : nat) (loc : Loc.t) (viio : view) (acs : Access_strength)
+    (data : val) : Exec.t (TState.t * Memory.t) string view :=
   let msg := Msg.make tid loc data in
   let is_release := acs =? AS_rel_or_acq in
-  let '(time, mem) :=
-    match Memory.fulfill msg (TState.prom ts) mem with
-    | Some t => (t, mem)
-    | None => Memory.promise msg mem
-    end in
+  ts ← mget fst;
+  otime ← Exec.liftSt snd $ Memory.fulfill msg (TState.prom ts);
+  time ← from_option mret (Exec.liftSt snd $ Memory.promise msg) otime;
   let vbob :=
     ts.(TState.vdmbst) ⊔ ts.(TState.vdmb) ⊔ ts.(TState.vdsb)
     ⊔ ts.(TState.vcse) ⊔ ts.(TState.vacq)
     ⊔ view_if is_release (ts.(TState.vrd) ⊔ ts.(TState.vwr)) in
   let vpre := ts.(TState.vspec) ⊔ vbob ⊔ viio in
   guard_discard (vpre ⊔ (TState.coh ts loc) < time)%nat;;
-  let ts :=
-    ts |> set TState.prom (delete time)
-       |> TState.update_coh loc time
-       |> TState.update TState.vwr time
-       |> TState.update TState.vrel (view_if is_release time)
-  in mret (ts, mem, time).
+  mset (TState.prom ∘ fst) $ delete time;;
+  mset fst $ TState.update_coh loc time;;
+  mset fst $ TState.update TState.vwr time;;
+  mset fst $ TState.update TState.vrel (view_if is_release time);;
+  mret time.
 
 
 (** Tries to perform a memory write.
@@ -1257,51 +1253,56 @@ Definition write_mem (tid : nat) (loc : Loc.t) (viio : view)
     If the store is exclusive the write may succeed or fail and the third
     return value indicate the success (true for success, false for error) *)
 Definition write_mem_xcl (tid : nat) (loc : Loc.t) (viio : view)
-    (ak : Explicit_access_kind) (ts : TState.t) (mem : Memory.t) (data : val)
-    : Exec.t string (TState.t * Memory.t):=
+    (ak : Explicit_access_kind) (data : val)
+    : Exec.t (TState.t * Memory.t) string () :=
   let acs := Explicit_access_kind_strength ak in
   let acv := Explicit_access_kind_variety ak in
   guard_or "Atomic RMV unsupported" (acv = AV_atomic_rmw);;
   let xcl := acv =? AV_exclusive in
   if xcl then
-    '(ts, mem, time) ← write_mem tid loc viio acs ts mem data;
+    time ← write_mem tid loc viio acs data;
+    '(ts, mem) ← mGet;
     match TState.xclb ts with
     | None => mdiscard
     | Some (xtime, xview) =>
         guard_discard' (Memory.exclusive loc xtime (Memory.cut_after time mem))
     end;;
-    let ts := TState.set_fwdb loc (FwdItem.make time viio true) ts in
-    mret (TState.clear_xclb ts, mem)
+    mset fst $ TState.set_fwdb loc (FwdItem.make time viio true);;
+    mset fst TState.clear_xclb
   else
-    '(ts, mem, time) ← write_mem tid loc viio acs ts mem data;
-    let ts := TState.set_fwdb loc (FwdItem.make time viio false) ts in
-    mret (ts, mem).
+    time ← write_mem tid loc viio acs data;
+    mset fst $ TState.set_fwdb loc (FwdItem.make time viio false).
 
-Definition run_cse (iis : IIS.t) (ts : TState.t) : IIS.t * TState.t :=
-  let vpost :=
-    ts.(TState.vspec) ⊔ ts.(TState.vcse)
-    ⊔ ts.(TState.vdsb) ⊔ ts.(TState.vmsr)
-  in
-  (IIS.add vpost iis, TState.cse vpost ts).
+Definition run_cse : Exec.t (TState.t * IIS.t) string () :=
+  mSet
+    (λ '(ts, iis),
+      let vpost :=
+        ts.(TState.vspec) ⊔ ts.(TState.vcse)
+        ⊔ ts.(TState.vdsb) ⊔ ts.(TState.vmsr)
+      in (TState.cse vpost ts, IIS.add vpost iis)).
 
 (** Perform a barrier, mostly view shuffling *)
-Definition run_barrier (iis : IIS.t) (ts : TState.t) (barrier : barrier) :
-  Exec.t string (IIS.t * TState.t) :=
+Definition run_barrier (barrier : barrier) :
+  Exec.t (TState.t * IIS.t) string () :=
+  ts ← mget fst;
   match barrier with
   | Barrier_DMB dmb => (* dmb *)
-       match dmb.(DxB_types) with
+      match dmb.(DxB_types) with
       | MBReqTypes_All (* dmb sy *) =>
           let vpost :=
             ts.(TState.vrd) ⊔ ts.(TState.vwr)
             ⊔ ts.(TState.vcse) ⊔ ts.(TState.vdsb)
           in
-          mret (IIS.add vpost iis, TState.update TState.vdmb vpost ts)
+          mset fst $ TState.update TState.vdmb vpost;;
+          mset snd $ IIS.add vpost
       | MBReqTypes_Reads (* dmb ld *) =>
           let vpost := ts.(TState.vrd) ⊔ ts.(TState.vcse) ⊔ ts.(TState.vdsb) in
-          mret (IIS.add vpost iis, TState.update TState.vdmb vpost ts)
+          mset fst $ TState.update TState.vdmb vpost;;
+          mset snd $ IIS.add vpost
       | MBReqTypes_Writes (* dmb st *) =>
           let vpost := ts.(TState.vwr) ⊔ ts.(TState.vcse) ⊔ ts.(TState.vdsb) in
-          mret (IIS.add vpost iis, TState.update TState.vdmbst vpost ts)
+          mset fst $ TState.update TState.vdmbst vpost;;
+          mset snd $ IIS.add vpost
       end
   | Barrier_DSB dmb => (* dsb *)
       guard_or "Non-shareable barrier are not supported"
@@ -1313,21 +1314,23 @@ Definition run_barrier (iis : IIS.t) (ts : TState.t) (barrier : barrier) :
             ⊔ ts.(TState.vdmb) ⊔ ts.(TState.vdmbst)
             ⊔ ts.(TState.vcse) ⊔ ts.(TState.vdsb) ⊔ ts.(TState.vtlbi)
           in
-          mret (IIS.add vpost iis, TState.update TState.vdsb vpost ts)
+          mset fst $ TState.update TState.vdsb vpost;;
+          mset snd $ IIS.add vpost
       | MBReqTypes_Reads (* dsb ld *) =>
           let vpost := ts.(TState.vrd) ⊔ ts.(TState.vcse) ⊔ ts.(TState.vdsb) in
-          mret (IIS.add vpost iis, TState.update TState.vdsb vpost ts)
+          mset fst $ TState.update TState.vdsb vpost;;
+          mset snd $ IIS.add vpost
       | MBReqTypes_Writes (* dsb st *) =>
           let vpost := ts.(TState.vwr) ⊔ ts.(TState.vcse) ⊔ ts.(TState.vdsb) in
-          mret (IIS.add vpost iis, TState.update TState.vdsb vpost ts)
+          mset fst $ TState.update TState.vdsb vpost;;
+          mset snd $ IIS.add vpost
       end
-  | Barrier_ISB () => mret (run_cse iis ts)
+  | Barrier_ISB () => run_cse
   | _ => mthrow "Unsupported barrier"
   end.
 
-Definition run_tlbi (tid : nat) (iis : IIS.t) (ts : TState.t) (view : nat)
-  (tlbi : TLBIInfo) (mem : Memory.t)
-  : Exec.t string (IIS.t * TState.t * Memory.t) :=
+Definition run_tlbi (tid : nat) (view : nat) (tlbi : TLBIInfo) :
+    Exec.t (TState.t * Memory.t * IIS.t) string () :=
   guard_or
     "Non-shareable TLBIs are not supported"
     (tlbi.(TLBIInfo_shareability) = Shareability_NSH);;
@@ -1337,6 +1340,8 @@ Definition run_tlbi (tid : nat) (iis : IIS.t) (ts : TState.t) (view : nat)
   let asid := tlbi.(TLBIInfo_rec).(TLBIRecord_asid) in
   let last := tlbi.(TLBIInfo_rec).(TLBIRecord_level) =? TLBILevel_Last in
   let va := bv_extract 12 36 (tlbi.(TLBIInfo_rec).(TLBIRecord_address)) in
+  ts ← mget (fst ∘ fst);
+  iis ← mget snd;
   let vpre := ts.(TState.vcse) ⊔ ts.(TState.vdsb) ⊔ ((*iio*) IIS.strict iis)
               ⊔ view ⊔ ts.(TState.vspec) in
   '(tlbiev : TLBI.t) ←
@@ -1347,80 +1352,72 @@ Definition run_tlbi (tid : nat) (iis : IIS.t) (ts : TState.t) (view : nat)
     | TLBIOp_VA => mret $ TLBI.Va tid asid va last
     | _ => mthrow "Unsupported kind of TLBI"
     end;
-  let '(time, mem) :=
-    match Memory.fulfill tlbiev (TState.prom ts) mem with
-    | Some t => (t, mem)
-    | None => Memory.promise tlbiev mem
-    end in
+  otime ← Exec.liftSt (snd ∘ fst) $ Memory.fulfill tlbiev (TState.prom ts);
+  time ← from_option mret (Exec.liftSt (snd ∘ fst) $ Memory.promise tlbiev) otime;
   guard_discard (vpre < time)%nat;;
-  let ts :=
-    ts |> set TState.prom (delete time)
-       |> TState.update TState.vtlbi time
-       |> TState.tlbi_cse time
-  in
-  mret (IIS.add time iis, ts, mem).
-
-
+  mset (TState.prom ∘ fst ∘ fst) $ delete time;;
+  mset (fst ∘ fst) $ TState.update TState.vtlbi time;;
+  mset (fst ∘ fst) $ TState.tlbi_cse time;;
+  mset snd $ IIS.add time.
 
 
 (** Runs an outcome. *)
 Definition run_outcome (tid : nat) (initmem : memoryMap) (out : outcome) :
-   stateT (TState.t * Memory.t * IIS.t) (Exec.t string) (eff_ret out) :=
-  λ '(ts, mem, iis),
+    Exec.t (TState.t * Memory.t * IIS.t) string (eff_ret out) :=
   let initmem := Memory.initial_from_memMap initmem in
   match out with
   | RegWrite reg racc val =>
       guard_or
         "Non trivial write reg access types unsupported"
         (bool_decide (racc ≠ None));;
+      iis ← mget snd;
       let vreg := IIS.strict iis in
       match Reg.from_arch reg with
       | Some Reg.PC =>
-          let ts := ts
-                    |> TState.update TState.vspec vreg
-                    |> setv TState.pc (regt_to_bv64 val) in
-          mret (ts, mem, iis, ())
+          mset (fst ∘ fst) $ TState.update TState.vspec vreg;;
+          msetv (TState.pc ∘ fst ∘ fst) (regt_to_bv64 val)
       | Some (Reg.App app) =>
-          let ts := TState.set_reg app (regt_to_bv64 val, vreg) ts in
-          mret (ts, mem, iis, ())
+          mset (fst ∘ fst) $ TState.set_reg app (regt_to_bv64 val, vreg)
       | Some (Reg.Sys sys) => mthrow "TODO"
       | None => mthrow "Writing to unsupported system register"
       end
   | RegRead reg direct => mthrow "TODO"
   | MemRead 8 rr =>
-      '(ts, iis, val) ← run_mem_read rr iis ts initmem mem;
-      mret (ts, mem, iis, inl (val, None))
+      val ← run_mem_read rr initmem;
+      mret (inl (val, None))
   | MemRead 4 rr => (* ifetch *)
-      opcode ← run_mem_read4 rr iis ts initmem mem;
-      mret (ts, mem, iis, inl (opcode, None))
+      opcode ← Exec.liftSt (snd ∘ fst) $ run_mem_read4 rr initmem;
+      mret (inl (opcode, None))
   | MemRead _ _ => mthrow "Memory read of size other than 8 or 4"
   | MemWriteAddrAnnounce _ _ _ _ =>
-      let vaddr := iis.(IIS.strict) in
-      let ts := TState.update TState.vspec vaddr ts in
-      mret (ts, mem, iis, ())
+      vaddr ← mget (IIS.strict ∘ snd);
+      mset (fst ∘ fst) $ TState.update TState.vspec vaddr
   | MemWrite 8 wr =>
       addr ← Exec.error_none "PA not supported" $ Loc.from_pa wr.(WriteReq.pa);
-      let viio := iis.(IIS.strict) in
+      viio ← mget (IIS.strict ∘ snd);
       let data := wr.(WriteReq.value) in
       match wr.(WriteReq.access_kind) with
       | AK_explicit eak =>
-          '(ts, mem) ← write_mem_xcl tid addr viio eak ts mem data;
-          mret (ts, mem, iis, inl true)
+          Exec.liftSt fst $ write_mem_xcl tid addr viio eak data;;
+          mret (inl true)
       | AK_ifetch () => mthrow "Write of type ifetch ???"
       | AK_ttw () => mthrow "Write of type TTW ???"
       | _ => mthrow "Unsupported non-explicit write"
       end
   | MemWrite _ _ => mthrow "Memory write of size other than 8"
   | Barrier barrier =>
-      '(iis, ts) ← run_barrier iis ts barrier;
-      mret (ts, mem, iis, ())
+      Exec.liftSt_full
+        (λ '(ts,mem,iis), (ts,iis))
+        (λ '(ts,iis) '(_,mem,_), (ts,mem,iis))
+        $ run_barrier barrier
   | TlbOp tlbi =>
-      let viio := iis.(IIS.strict) in
-      '(iis, ts, mem) ← run_tlbi tid iis ts viio tlbi mem;
-      mret (ts, mem, iis, ())
+      viio ← mget (IIS.strict ∘ snd);
+      run_tlbi tid viio tlbi
   | ReturnException =>
-      let '(iis, ts) := run_cse iis ts in
-      mret (ts, mem, iis, ())
+      Exec.liftSt_full
+      (λ '(ts,mem,iis), (ts,iis))
+      (λ '(ts,iis) '(_,mem,_), (ts,mem,iis))
+      $ run_cse
   | GenericFail s => mthrow ("Instruction failure: " ++ s)%string
   | _ => mthrow "Unsupported outcome"
   end.

--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -1178,28 +1178,28 @@ Definition read_pte (vaddr : view)
 (** Run a MemRead outcome.
     Returns the new thread state, the vpost of the read and the read value. *)
 Definition run_mem_read (rr : ReadReq.t 8) (init : Memory.initial) :
-    Exec.t (TState.t * Memory.t * IIS.t) string val :=
+    Exec.t (PPState.t TState.t Ev.t IIS.t) string val :=
   addr ← Exec.error_none "PA not supported" $ Loc.from_pa rr.(ReadReq.pa);
-  iis ← mget snd;
+  iis ← mget PPState.iis;
   let vaddr := iis.(IIS.strict) in
   let va : bv 64 := default (Loc.to_va addr) rr.(ReadReq.va) in
   match rr.(ReadReq.access_kind) with
   | AK_explicit eak =>
-      trans_res ← mget ((.!! (bv_extract 12 36 va)) ∘ IIS.trs ∘ snd);
+      trans_res ← mget ((.!! (bv_extract 12 36 va)) ∘ IIS.trs ∘ PPState.iis);
       let inv :=
         trans_res |> fmap (fun tr => tr.(IIS.TransRes.invalidation)) |> default (0 % nat)
       in
-      '(view, val) ← Exec.liftSt fst $ read_mem_explicit addr vaddr inv eak init;
-      mset snd $ IIS.add view;;
+      '(view, val) ← Exec.liftSt (PPState.state ×× PPState.mem) $ read_mem_explicit addr vaddr inv eak init;
+      mset PPState.iis $ IIS.add view;;
       mret val
   | AK_ttw () =>
       '(view, val) ← Exec.partial_liftSt
-                      (λ '(ts,mem,iis), if iis.(IIS.trs) !! (bv_extract 12 36 va) then True else False)
+                      (λ ppst, if (ppst.(PPState.iis)).(IIS.trs) !! (bv_extract 12 36 va) then True else False)
                       "TTW read before translation start"
-                      (λ '(ts,mem,iis) H_some, (ts, unfold_if_Some H_some))
-                      (λ '(ts,tres) '(_,mem,iis), (ts, mem, IIS.set_trs (bv_extract 12 36 va) tres iis))
+                      (λ ppst H_some, (ppst.(PPState.state), unfold_if_Some H_some))
+                      (λ '(ts,tres) ppst, ppst |> setv PPState.state ts |> set PPState.iis (IIS.set_trs (bv_extract 12 36 va) tres))
                       $ read_pte vaddr rr.(ReadReq.translation);
-      mset snd $ IIS.add view;;
+      mset PPState.iis $ IIS.add view;;
       mret val
   | AK_ifetch () => mthrow "8 bytes ifetch ???"
   | _ => mthrow "Only ifetch, ttw and explicit accesses supported"
@@ -1330,7 +1330,7 @@ Definition run_barrier (barrier : barrier) :
   end.
 
 Definition run_tlbi (tid : nat) (view : nat) (tlbi : TLBIInfo) :
-    Exec.t (TState.t * Memory.t * IIS.t) string () :=
+    Exec.t (PPState.t TState.t Ev.t IIS.t) string () :=
   guard_or
     "Non-shareable TLBIs are not supported"
     (tlbi.(TLBIInfo_shareability) = Shareability_NSH);;
@@ -1340,8 +1340,8 @@ Definition run_tlbi (tid : nat) (view : nat) (tlbi : TLBIInfo) :
   let asid := tlbi.(TLBIInfo_rec).(TLBIRecord_asid) in
   let last := tlbi.(TLBIInfo_rec).(TLBIRecord_level) =? TLBILevel_Last in
   let va := bv_extract 12 36 (tlbi.(TLBIInfo_rec).(TLBIRecord_address)) in
-  ts ← mget (fst ∘ fst);
-  iis ← mget snd;
+  ts ← mget PPState.state;
+  iis ← mget PPState.iis;
   let vpre := ts.(TState.vcse) ⊔ ts.(TState.vdsb) ⊔ ((*iio*) IIS.strict iis)
               ⊔ view ⊔ ts.(TState.vspec) in
   '(tlbiev : TLBI.t) ←
@@ -1352,32 +1352,32 @@ Definition run_tlbi (tid : nat) (view : nat) (tlbi : TLBIInfo) :
     | TLBIOp_VA => mret $ TLBI.Va tid asid va last
     | _ => mthrow "Unsupported kind of TLBI"
     end;
-  otime ← Exec.liftSt (snd ∘ fst) $ Memory.fulfill tlbiev (TState.prom ts);
-  time ← from_option mret (Exec.liftSt (snd ∘ fst) $ Memory.promise tlbiev) otime;
+  otime ← Exec.liftSt PPState.mem $ Memory.fulfill tlbiev (TState.prom ts);
+  time ← from_option mret (Exec.liftSt PPState.mem $ Memory.promise tlbiev) otime;
   guard_discard (vpre < time)%nat;;
-  mset (TState.prom ∘ fst ∘ fst) $ delete time;;
-  mset (fst ∘ fst) $ TState.update TState.vtlbi time;;
-  mset (fst ∘ fst) $ TState.tlbi_cse time;;
-  mset snd $ IIS.add time.
+  mset (TState.prom ∘ PPState.state) $ delete time;;
+  mset PPState.state $ TState.update TState.vtlbi time;;
+  mset PPState.state $ TState.tlbi_cse time;;
+  mset PPState.iis $ IIS.add time.
 
 
 (** Runs an outcome. *)
 Definition run_outcome (tid : nat) (initmem : memoryMap) (out : outcome) :
-    Exec.t (TState.t * Memory.t * IIS.t) string (eff_ret out) :=
+    Exec.t (PPState.t TState.t Ev.t IIS.t) string (eff_ret out) :=
   let initmem := Memory.initial_from_memMap initmem in
   match out with
   | RegWrite reg racc val =>
       guard_or
         "Non trivial write reg access types unsupported"
         (bool_decide (racc ≠ None));;
-      iis ← mget snd;
+      iis ← mget PPState.iis;
       let vreg := IIS.strict iis in
       match Reg.from_arch reg with
       | Some Reg.PC =>
-          mset (fst ∘ fst) $ TState.update TState.vspec vreg;;
-          msetv (TState.pc ∘ fst ∘ fst) (regt_to_bv64 val)
+          mset PPState.state $ TState.update TState.vspec vreg;;
+          msetv (TState.pc ∘ PPState.state) (regt_to_bv64 val)
       | Some (Reg.App app) =>
-          mset (fst ∘ fst) $ TState.set_reg app (regt_to_bv64 val, vreg)
+          mset PPState.state $ TState.set_reg app (regt_to_bv64 val, vreg)
       | Some (Reg.Sys sys) => mthrow "TODO"
       | None => mthrow "Writing to unsupported system register"
       end
@@ -1386,19 +1386,19 @@ Definition run_outcome (tid : nat) (initmem : memoryMap) (out : outcome) :
       val ← run_mem_read rr initmem;
       mret (inl (val, None))
   | MemRead 4 rr => (* ifetch *)
-      opcode ← Exec.liftSt (snd ∘ fst) $ run_mem_read4 rr initmem;
+      opcode ← Exec.liftSt PPState.mem $ run_mem_read4 rr initmem;
       mret (inl (opcode, None))
   | MemRead _ _ => mthrow "Memory read of size other than 8 or 4"
   | MemWriteAddrAnnounce _ _ _ _ =>
-      vaddr ← mget (IIS.strict ∘ snd);
-      mset (fst ∘ fst) $ TState.update TState.vspec vaddr
+      vaddr ← mget (IIS.strict ∘ PPState.iis);
+      mset PPState.state $ TState.update TState.vspec vaddr
   | MemWrite 8 wr =>
       addr ← Exec.error_none "PA not supported" $ Loc.from_pa wr.(WriteReq.pa);
-      viio ← mget (IIS.strict ∘ snd);
+      viio ← mget (IIS.strict ∘ PPState.iis);
       let data := wr.(WriteReq.value) in
       match wr.(WriteReq.access_kind) with
       | AK_explicit eak =>
-          Exec.liftSt fst $ write_mem_xcl tid addr viio eak data;;
+          Exec.liftSt (PPState.state ×× PPState.mem) $ write_mem_xcl tid addr viio eak data;;
           mret (inl true)
       | AK_ifetch () => mthrow "Write of type ifetch ???"
       | AK_ttw () => mthrow "Write of type TTW ???"
@@ -1406,18 +1406,12 @@ Definition run_outcome (tid : nat) (initmem : memoryMap) (out : outcome) :
       end
   | MemWrite _ _ => mthrow "Memory write of size other than 8"
   | Barrier barrier =>
-      Exec.liftSt_full
-        (λ '(ts,mem,iis), (ts,iis))
-        (λ '(ts,iis) '(_,mem,_), (ts,mem,iis))
-        $ run_barrier barrier
+      Exec.liftSt (PPState.state ×× PPState.iis) $ run_barrier barrier
   | TlbOp tlbi =>
-      viio ← mget (IIS.strict ∘ snd);
+      viio ← mget (IIS.strict ∘ PPState.iis);
       run_tlbi tid viio tlbi
   | ReturnException =>
-      Exec.liftSt_full
-      (λ '(ts,mem,iis), (ts,iis))
-      (λ '(ts,iis) '(_,mem,_), (ts,mem,iis))
-      $ run_cse
+      Exec.liftSt (PPState.state ×× PPState.iis) $ run_cse
   | GenericFail s => mthrow ("Instruction failure: " ++ s)%string
   | _ => mthrow "Unsupported outcome"
   end.
@@ -1453,10 +1447,13 @@ Definition VMPromising_nocert isem :=
      state *)
 
 Definition seq_step (isem : iMon ()) (tid : nat) (initmem : memoryMap)
-  : relation (TState.t * Memory.t) :=
+  : relation (TState.t * PromMemory.t Ev.t) :=
   let handler := run_outcome tid initmem in
-  λ tsmem tsmem',
-    tsmem' ∈ (cinterp handler isem (tsmem, IIS.init) |$> fst ∘ fst).
+  λ '(ts, mem) '(ts', mem'),
+    CResult.Ok (ts', mem') ∈
+      cinterp handler isem (PPState.Make ts mem IIS.init)
+      |> Exec.to_state_result_list
+      |$> (fmap (M := CResult.result _) (λ '(PPState.Make ts mem iis), (ts, mem))).
 
 Definition allowed_promises_cert (isem : iMon ()) tid (initmem : memoryMap)
   (ts : TState.t) (mem : Memory.t) : propset Ev.t :=

--- a/Common/CDestruct.v
+++ b/Common/CDestruct.v
@@ -883,3 +883,19 @@ Proof. tcclean. tauto. Qed.
 Instance cdestruct_not_or_and b P Q :
   CDestrSimpl b (¬ (P ∨ Q)) (¬ P ∧ ¬ Q).
 Proof. tcclean. naive_solver. Qed.
+
+Instance cdestruct_or_False_l b P :
+  CDestrSimpl b (False ∨ P) P.
+Proof. tcclean. naive_solver. Qed.
+
+Instance cdestruct_or_False_r b P :
+  CDestrSimpl b (P ∨ False) P.
+Proof. tcclean. naive_solver. Qed.
+
+Instance cdestruct_and_True_l b P :
+  CDestrSimpl b (True ∧ P) P.
+Proof. tcclean. naive_solver. Qed.
+
+Instance cdestruct_and_True_r b P :
+  CDestrSimpl b (P ∧ True) P.
+Proof. tcclean. naive_solver. Qed.

--- a/Common/CDestruct.v
+++ b/Common/CDestruct.v
@@ -887,10 +887,6 @@ Instance cdestruct_not_or_and b P Q :
   CDestrSimpl b (¬ (P ∨ Q)) (¬ P ∧ ¬ Q).
 Proof. tcclean. naive_solver. Qed.
 
-Instance cdestruct_is_Some {A} (x : option A) :
-  CDestrSimpl false (is_Some x) (∃ y, x = Some y).
-Proof. tcclean. naive_solver. Qed.
-
 Instance cdestruct_or_False_l b P :
   CDestrSimpl b (False ∨ P) P.
 Proof. tcclean. naive_solver. Qed.

--- a/Common/CDestruct.v
+++ b/Common/CDestruct.v
@@ -291,6 +291,9 @@ Global Hint Extern 3 (ObvTrue _) =>
 Global Hint Extern 4 (ObvTrue _) =>
          constructor; symmetry; assumption : typeclass_instances.
 
+#[global] Instance obv_true_not_False : ObvTrue (¬ False).
+Proof. now tcclean. Qed.
+
 (** * CDestruct
 
 See the top of the file comment for details about what [cdestruct] does. *)
@@ -882,6 +885,10 @@ Proof. tcclean. tauto. Qed.
 
 Instance cdestruct_not_or_and b P Q :
   CDestrSimpl b (¬ (P ∨ Q)) (¬ P ∧ ¬ Q).
+Proof. tcclean. naive_solver. Qed.
+
+Instance cdestruct_is_Some {A} (x : option A) :
+  CDestrSimpl false (is_Some x) (∃ y, x = Some y).
 Proof. tcclean. naive_solver. Qed.
 
 Instance cdestruct_or_False_l b P :

--- a/Common/CList.v
+++ b/Common/CList.v
@@ -347,6 +347,24 @@ Lemma Forall2_diag A (P : A → A → Prop) l:
   Forall2 P l l ↔ ∀ x ∈ l, P x x.
 Proof. induction l; sauto lq:on. Qed.
 
+(** ** filter_partition *)
+
+Fixpoint filter_partition {A} P `{∀ x : A, Decision (P x)} (l : list A) :
+    list A * list A :=
+  if l is a :: ar
+  then let '(p_list, not_p_list) := filter_partition P ar in
+    (if decide (P a) then (a :: p_list, not_p_list) else (p_list, a :: not_p_list))
+  else ([],[]).
+
+Lemma filter_partition_spec {A} P `{∀ x : A, Decision (P x)} (l : list A) :
+  filter_partition P l = (filter P l, filter (λ x, ¬ P x) l).
+Proof.
+  induction l; cbn; first done.
+  cdestruct |- *** as ?? #CDestrMatch #CDestrSplitGoal.
+  all: rewrite IHl.
+  all: cdestruct |- ***.
+Qed.
+
 (** ** fold_left invariant proofs *)
 
 (** Proofs along fold_left using an invariant.

--- a/Common/CList.v
+++ b/Common/CList.v
@@ -43,7 +43,7 @@
 (******************************************************************************)
 
 Require Import Options.
-Require Import CBase CBool CMaps CArith CDestruct.
+Require Import CBase CBool CMaps CArith.
 From stdpp Require Import base.
 From stdpp Require Export list.
 From stdpp Require Import finite.
@@ -347,24 +347,6 @@ Lemma Forall2_diag A (P : A → A → Prop) l:
   Forall2 P l l ↔ ∀ x ∈ l, P x x.
 Proof. induction l; sauto lq:on. Qed.
 
-(** ** filter_partition *)
-
-Fixpoint filter_partition {A} P `{∀ x : A, Decision (P x)} (l : list A) :
-    list A * list A :=
-  if l is a :: ar
-  then let '(p_list, not_p_list) := filter_partition P ar in
-    (if decide (P a) then (a :: p_list, not_p_list) else (p_list, a :: not_p_list))
-  else ([],[]).
-
-Lemma filter_partition_spec {A} P `{∀ x : A, Decision (P x)} (l : list A) :
-  filter_partition P l = (filter P l, filter (λ x, ¬ P x) l).
-Proof.
-  induction l; cbn; first done.
-  cdestruct |- *** as ?? #CDestrMatch #CDestrSplitGoal.
-  all: rewrite IHl.
-  all: cdestruct |- ***.
-Qed.
-
 (** ** fold_left invariant proofs *)
 
 (** Proofs along fold_left using an invariant.
@@ -375,26 +357,8 @@ Lemma fold_left_inv {C B} (I : C → list B → Prop) (f : C → B → C)
   (I i l)
   → (∀ (a : C) (x : B) (tl : list B), x ∈ l → I a (x :: tl) → I (f a x) tl)
   → I (fold_left f l i) [].
-Proof.
   generalize dependent i.
   induction l; sauto lq:on.
-Qed.
-
-Lemma fold_left_inv_complete_list {C B} (I : C → list B → list B → Prop) (f : C → B → C)
-    (l l' : list B) (i : C) :
-  (I i l [])
-  → (∀ (a : C) (x : B) (tl strt : list B), x ∈ l → I a (x :: tl) strt → I (f a x) tl (x :: strt))
-  → I (fold_left f l i) [] (rev l).
-Proof.
-  replace (rev l) with (rev l ++ []) by by rewrite app_nil_r.
-  generalize (@nil B) at 1 3.
-  revert dependent i.
-  induction l.
-  1: done.
-  cdestruct |- ***.
-  rewrite <- app_assoc.
-  eapply IHl.
-  all: intros; eapply H0; set_solver.
 Qed.
 
 (** Tries to find a fold_left in the goal and pose the proofs of the
@@ -416,7 +380,6 @@ Lemma fold_left_inv_ND {C B} (I : C → list B → Prop) (f : C → B → C)
   → (I i l)
   → (∀ (a : C) (x : B) (t : list B), x ∈ l → x ∉ t → I a (x :: t) → I (f a x) t)
   → I (fold_left f l i) [].
-Proof.
   generalize dependent i.
   induction l; sauto lq:on.
 Qed.

--- a/Common/CList.v
+++ b/Common/CList.v
@@ -70,10 +70,6 @@ Proof. tcclean. unfold mret, list_ret. set_solver. Qed.
 
 #[export] Instance list_elements {A} : Elements A (list A) := λ x, x.
 
-#[global] Instance cdestruct_list_elements b {A} x (l : list A) :
-  CDestrSimpl b (x ∈ elements l) (x ∈ l).
-Proof. tcclean. done. Qed.
-
 (** * List simplification *)
 
 #[global] Hint Rewrite <- app_assoc : list.

--- a/Common/COption.v
+++ b/Common/COption.v
@@ -56,12 +56,6 @@ Definition othrow `{MThrow E M} `{MRet M} {A} (err : E) (v : option A) : M A :=
 
 Notation ofail := (othrow ()).
 
-Definition unfold_if_Some {A} {o : option A} : (if o then True else False) → A :=
-  match o as o0 return ((if o0 then True else False) → A) with
-  | Some a => λ _ : True, a
-  | None => λ H : False, match H with end
-  end.
-
 (** * EqSomeUnfold *)
 
 Class EqSomeUnfold {A} (oa : option A) (a : A) (P : Prop) :=

--- a/Common/COption.v
+++ b/Common/COption.v
@@ -228,6 +228,11 @@ Proof. tcclean. naive_solver. Qed.
   CDestrSimpl g (oa = None) P :=
   cdestr_simpl g (@eq_none_unfold T oa P _).
 
+(** * CDestrSimpl *)
+
+#[export] Instance cdestruct_is_Some {A} (x : option A) :
+  CDestrSimpl false (is_Some x) (∃ y, x = Some y).
+Proof. tcclean. naive_solver. Qed.
 
 (** * Hint database for options *)
 Hint Extern 5 (_ = Some _) => progress (apply eq_some_unfold) : option.

--- a/Common/COption.v
+++ b/Common/COption.v
@@ -56,6 +56,12 @@ Definition othrow `{MThrow E M} `{MRet M} {A} (err : E) (v : option A) : M A :=
 
 Notation ofail := (othrow ()).
 
+Definition unfold_if_Some {A} {o : option A} : (if o then True else False) → A :=
+  match o as o0 return ((if o0 then True else False) → A) with
+  | Some a => λ _ : True, a
+  | None => λ H : False, match H with end
+  end.
+
 (** * EqSomeUnfold *)
 
 Class EqSomeUnfold {A} (oa : option A) (a : A) (P : Prop) :=

--- a/Common/CResult.v
+++ b/Common/CResult.v
@@ -44,6 +44,7 @@
 
 Require Import CBase.
 Require Import Options.
+Require Import CDestruct.
 From stdpp Require Import option.
 
 (** The point of this module is to keep the [sum] type symmetric and use this to
@@ -134,6 +135,16 @@ Section Result.
       unfold is_Ok;
       naive_solver.
   Defined.
+
+  #[export] Instance cdestruct_is_Ok r :
+    CDestrSimpl false (is_Ok r) (∃ o, r = Ok o).
+  Proof. tcclean. now unfold is_Ok. Qed.
+
+  #[export] Instance obv_true_is_Ok_Ok x : ObvTrue (is_Ok (Ok x)).
+  Proof. tcclean. unfold is_Ok. eauto. Qed.
+
+  #[export] Instance obv_false_is_Ok_Error x : ObvFalse (is_Ok (Error x)).
+  Proof. tcclean. unfold is_Ok. naive_solver. Qed.
 
   (** Unpack a result into any monad that supports that error type *)
   Definition unpack_result `{MThrow E M, MRet M} (r : result) : M A :=

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -105,6 +105,12 @@ Definition Results {St E A C} `{Elements A C} (s : C) : t St E A := λ st, make 
 
 #[global] Typeclasses Opaque choose_inst.
 
+#[global] Instance st_call_MState {St E} : MCall (MState St) (t St E) | 10 := λ eff,
+match eff with
+| MSet s => λ _, (mret () : t St E ()) s
+| MGet => λ s, (mret s : t St E St) s
+end.
+
 Lemma mdiscard_eq {St E A} : mdiscard =@{t St E A} (λ st, make [] []).
 Proof. reflexivity. Qed.
 
@@ -112,9 +118,17 @@ Proof. reflexivity. Qed.
   λ x r, x ∈ r.(results).
 #[global] Typeclasses Opaque elem_of_results.
 
-(* #[global] Instance elem_of_results_unit_state {E A} : ElemOf A (res () E A) :=
+#[global] Instance elem_of_results_no_state {St E A} : ElemOf A (res St E A) :=
   λ x r, x ∈ (map snd r.(results)).
-#[global] Typeclasses Opaque elem_of_results. *)
+#[global] Typeclasses Opaque elem_of_results_no_state.
+
+
+#[global] Instance elem_of_result {St E A} : ElemOf (result E A) (res St E A) :=
+  λ x e, match x with
+         | Ok v => v ∈ e
+         | Error err => err ∈ (map snd e.(errors))
+         end.
+#[global] Typeclasses Opaque elem_of_result.
 
 (** Takes an option but convert None into an error *)
 Definition error_none {St E A} (e : E) : option A -> t St E A :=

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -106,10 +106,6 @@ Definition res_Results {E A C} `{Elements A C} (s : C) : res E A :=
 #[global] Instance res_choose_inst {E} : MChoose (res E) :=
   λ '(ChooseFin n), @res_Results  _ (Fin.t n) _ _ (enum (fin n)).
 
-(** Mapping function for both successful and error states *)
-Definition res_states_map {St St' E A} (f : St → St') (r : res (St * E) (St * A)) :=
-  make (map (λ '(st, a), (f st, a)) r.(results)) (map (λ '(st, e), (f st, e)) r.(errors)).
-
 (** Convert an execution result into a list of results *)
 Definition to_result_list `(e : res E A) : list (result E A) :=
   map Ok e.(results) ++ map Error e.(errors).
@@ -176,8 +172,11 @@ Definition liftSt_full {St St' E A} (getter : St → St') (setter : St' → St �
 Definition liftSt {St St' E A} (getter : St → St') `{Setter St St' getter} (inner : Exec.t St' E A) : Exec.t St E A :=
   liftSt_full getter (@setv _ _ getter _) inner.
 
-Definition import_res `(r : res (St * E) (St * A)) : t St E A :=
-  λ _, r.
+Definition lift_res_set_full {St' St} (setter : St' → St → St) `(r : res (St' * E) (St' * A)) : t St E A :=
+  λ st, make (map (λ '(st', v), (setter st' st, v)) r.(results)) (map (λ '(st', e), (setter st' st, e)) r.(errors)).
+
+Definition lift_res_set {St' St} (getter : St → St') `{Setter St St' getter} `(r : res (St' * E) (St' * A)) : t St E A :=
+  lift_res_set_full (@setv _ _ getter _) r.
 
 #[global] Instance elem_of_results {E A} : ElemOf A (res E A) :=
   λ x r, x ∈ r.(results).

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -92,6 +92,7 @@ Definition to_state_result_list `(e : res (St * E) (St * A)) : list (result St S
 
 Definition t {St E A} := St → res (St * E) (St * A).
 Arguments t : clear implicits.
+#[global] Typeclasses Transparent t.
 
 (** Create an execution from a set of results, e.g. to convert from pure
     non-determinism to Exec *)
@@ -157,7 +158,7 @@ Definition liftSt_full {St St' E A} (getter : St → St') (setter : St' → St �
          ((λ '(st',a), (setter st' st, a)) <$> inner_res.(errors)).
 
 Definition liftSt {St St' E A} (getter : St → St') `{Setter St St' getter} (inner : Exec.t St' E A) : Exec.t St E A :=
-  liftSt_full getter (@setv _ _ _ _) inner.
+  liftSt_full getter (@setv _ _ getter _) inner.
 
 #[global] Instance elem_of_results {E A} : ElemOf A (res E A) :=
   λ x r, x ∈ r.(results).

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -198,7 +198,6 @@ Definition discard_none {St E A} : option A -> t St E A :=
 (** Maps the error to another error type. *)
 Definition map_error {St E E' A} (f : E -> E') (e : t St E A) : t St E' A :=
   λ st, let est := e st in make est.(results) (map (λ '(st', r), (st', f r)) est.(errors)).
-(** Merge the results of two executions *)
 
 (** * Unfold typeclass for execution results *)
 

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -176,7 +176,7 @@ Definition liftSt {St St' E A} (getter : St → St') `{Setter St St' getter} (in
          end.
 #[global] Typeclasses Opaque elem_of_result.
 
-#[global] Instance elem_of_result_state {St E A} : ElemOf (result E A) (res (St * E) (St * A)) :=
+#[global] Instance elem_of_result_no_state {St E A} : ElemOf (result E A) (res (St * E) (St * A)) :=
   λ x e, match x with
          | Ok v => v ∈ e
          | Error err => err ∈ (snd <$> e.(errors))

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -55,64 +55,68 @@ Require Import Effects.
 Module Exec.
 
 (** * Base definitions *)
-Record t {St E A : Type} := make {
+Record res {St E A : Type} := make {
     results: list (St * A);
     errors: list (St * E);
   }.
-Arguments t : clear implicits.
+Arguments res : clear implicits.
 Arguments make {_ _ _}.
 
 (** Decide if an execution has errors *)
-Definition has_error `(e : t St E A) :=
+Definition has_error `(e : res St E A) :=
   match e with
   | make _ [] => False
   | _ => True
   end.
-#[global] Instance has_error_dec `(e : t St E A): Decision (has_error e).
+#[global] Instance has_error_dec `(e : res St E A): Decision (has_error e).
 Proof. unfold_decide. Qed.
 
 (** Create an execution from a set of results, e.g. to convert from pure
     non-determinism to Exec *)
-Definition Results {E A C} `{Elements A C} (s : C) : t () E A := make (map ((),.) (elements s)) [].
+Definition Results {E A C} `{Elements A C} (s : C) : res () E A := make (map ((),.) (elements s)) [].
 
 (** Merge the results of two executions *)
-Definition merge {St E A} (e1 e2 : t St E A) :=
+Definition merge {St E A} (e1 e2 : res St E A) :=
   make (e1.(results) ++ e2.(results)) (e1.(errors) ++ e2.(errors)).
 #[global] Typeclasses Opaque merge.
 Arguments merge : simpl never.
 
 (** Convert an execution into a list of results *)
-Definition to_result_list `(e : t St E A) : list (result (St * E) (St * A)) :=
+Definition to_result_list `(e : res St E A) : list (result (St * E) (St * A)) :=
   map Ok e.(results) ++ map Error e.(errors).
 
-Definition s {St E A} := St → t St E A.
-Arguments s : clear implicits.
+Definition t {St E A} := St → res St E A.
+Arguments t : clear implicits.
 Arguments make {_ _ _}.
 
-#[global] Instance mret_inst {St E} : MRet (s St E) := λ _ v st, make [(st,v)] [].
+#[global] Instance mret_inst {St E} : MRet (t St E) := λ _ v st, make [(st,v)] [].
 
-#[global] Instance mbind_inst {St E} : MBind (s St E) :=
+#[global] Instance mbind_inst {St E} : MBind (t St E) :=
   λ _ _ f e st, foldr merge (make [] (e st).(errors)) (map (λ '(st', r), f r st') (e st).(results)).
 #[global] Typeclasses Opaque mbind_inst.
 
-#[global] Instance fmap_inst {St E} : FMap (s St E) :=
+#[global] Instance fmap_inst {St E} : FMap (t St E) :=
   λ _ _ f e st, make (map (λ '(st', r), (st', f r)) (e st).(results)) (e st).(errors).
 #[global] Typeclasses Opaque fmap_inst.
 
-#[global] Instance throw_inst {St E} : MThrow E (s St E) := λ _ e st, make [] [(st,e)].
+#[global] Instance throw_inst {St E} : MThrow E (t St E) := λ _ e st, make [] [(st,e)].
 
-#[global] Instance choose_inst {St E} : MChoose (s St E) :=
+#[global] Instance choose_inst {St E} : MChoose (t St E) :=
   λ '(ChooseFin n) st, make (map (st,.) (enum (fin n))) [].
 #[global] Typeclasses Opaque choose_inst.
 
-Lemma mdiscard_eq {St E A} : mdiscard =@{s St E A} (λ st, make [] []).
+Lemma mdiscard_eq {St E A} : mdiscard =@{t St E A} (λ st, make [] []).
 Proof. reflexivity. Qed.
 
-#[global] Instance elem_of_results {E A} : ElemOf A (s () E A) :=
+#[global] Instance elem_of_results {E A} : ElemOf A (t () E A) :=
   λ x e, x ∈ (map snd (e ()).(results)).
 #[global] Typeclasses Opaque elem_of_results.
 
-#[global] Instance elem_of_result {E A} : ElemOf (result E A) (s () E A) :=
+#[global] Instance elem_of_results_pair {E A} : ElemOf (() * A) (t () E A) :=
+  λ x e, x ∈ (e ()).(results).
+#[global] Typeclasses Opaque elem_of_results.
+
+#[global] Instance elem_of_result {E A} : ElemOf (result E A) (t () E A) :=
   λ x e, match x with
          | Ok v => v ∈ e
          | Error err => err ∈ (map snd (e ()).(errors))
@@ -120,25 +124,25 @@ Proof. reflexivity. Qed.
 #[global] Typeclasses Opaque elem_of_result.
 
 (** Takes an option but convert None into an error *)
-Definition error_none {E A} (e : E) : option A -> t E A :=
+Definition error_none {St E A} (e : E) : option A -> t St E A :=
   from_option mret (mthrow e).
 
 (** Takes an option but convert None into a discard *)
-Definition discard_none {E A} : option A -> t E A :=
+Definition discard_none {St E A} : option A -> t St E A :=
   from_option mret mdiscard.
 
 (** Maps the error to another error type. *)
-Definition map_error {E E' A} (f : E -> E') (e : t E A) : t E' A :=
-  make e.(results) (map f e.(errors)).
+Definition map_error {St E E' A} (f : E -> E') (e : t St E A) : t St E' A :=
+  λ st, make (e st).(results) (map (λ '(st', r), (st', f r)) (e st).(errors)).
 (** Merge the results of two executions *)
 
 (** * Unfold typeclass for results *)
 
-Class UnfoldElemOf {A E} (x : A) (e : t E A) (Q : Prop) :=
+Class UnfoldElemOf {A E} (x : A) (e : t () E A) (Q : Prop) :=
   {unfold_elem_of : x ∈ e ↔ Q}.
 #[global] Hint Mode UnfoldElemOf + + - + - : typeclass_instances.
 
-#[global] Instance unfold_elem_of_default {A E} (x : A) (e : t E A) :
+#[global] Instance unfold_elem_of_default {A E} (x : A) (e : t () E A) :
   UnfoldElemOf x e (x ∈ e) | 1000.
 Proof. done. Qed.
 
@@ -156,7 +160,7 @@ Proof. done. Qed.
   destruct b; cbn zeta match : typeclass_instances.
 
 #[global] Instance UnfoldElemOf_proper {A E} :
-  Proper (@eq A ==> @eq (t E A) ==> iff ==> iff) UnfoldElemOf.
+  Proper (@eq A ==> @eq (t () E A) ==> iff ==> iff) UnfoldElemOf.
 Proof. solve_proper2_tc. Qed.
 
 (** Enables Exec unfolding in regular set_unfold *)
@@ -172,44 +176,68 @@ Proof. tcclean. apply unfold_elem_of. Qed.
 (** ** Actual unfolding lemmas *)
 
 #[global] Instance unfold_elem_of_make {E A} x l l' P:
-  SetUnfoldElemOf x l P →
-  UnfoldElemOf x (make l l' : t E A) P.
+  SetUnfoldElemOf x (map snd l) P →
+  UnfoldElemOf x ((λ _, make l l') : t () E A) P.
 Proof. tcclean. naive_solver. Qed.
 
 #[global] Instance unfold_elem_of_mret {E A} x y:
-  UnfoldElemOf x (mret y : t E A) (x = y).
-Proof. tcclean. unfold mret, mret_inst. set_solver. Qed.
+  UnfoldElemOf x (mret y : t () E A) (x = y).
+Proof. tcclean. unfold mret, mret_inst, elem_of, elem_of_results. cbn in *. set_solver. Qed.
 
-#[global] Instance unfold_elem_of_merge {E A} x (e e' : t E A) P Q:
+#[global] Instance unfold_elem_of_merge {E A} x (e e' : t () E A) P Q:
   UnfoldElemOf x e P →
   UnfoldElemOf x e' Q →
-  UnfoldElemOf x (merge e e') (P ∨ Q).
-Proof. tcclean. unfold merge. destruct e. destruct e'. set_solver. Qed.
+  UnfoldElemOf x (λ _, merge (e ()) (e' ())) (P ∨ Q).
+Proof. tcclean. unfold merge, elem_of, elem_of_results. destruct e. destruct e'. set_solver. Qed.
 
-#[global] Instance unfold_elem_of_mbind {E A B} (x : B) (e : t E A) (f : A → t E B) P:
+#[global] Instance unfold_elem_of_mbind {E A B} (x : B) (e : t () E A) (f : A → t () E B) P:
   (∀ y, UnfoldElemOf y e (P y)) →
   UnfoldElemOf x (e ≫= f) (∃ y, P y ∧ x ∈ f y) | 20.
 Proof.
-  tcclean. deintro. intros _. destruct e as [l es]. cbn.
+  tcclean. deintro. intros _.
+  unfold mbind, mbind_inst, elem_of, elem_of_results.
+  destruct (e ()) as [l es].
+  cbn.
   setoid_rewrite unfold_elem_of.
-  induction l; set_solver.
+  induction l as [|[[] a ] lr [H H0]].
+  1: set_solver.
+  do 2 set_unfold.
+  split.
+  {
+    cdestruct |- *** as Hres ## cdestruct_or.
+    1: eexists a; unfold elem_of at 2, elem_of_results; set_unfold; split; eexists (_,_); split; last eapply Hres.
+    1-3: try reflexivity; now left.
+    enough (∃ x0 : A, (∃ x1 : () * A, x0 = x1.2 ∧ x1 ∈ lr) ∧ x ∈ f x0) by naive_solver.
+    eapply H.
+    eexists (_,_).
+    naive_solver.
+  }
+  {
+    cdestruct |- *** as Hres ## cdestruct_or.
+    1: eexists (_,_); split; [|left]; cbn; try reflexivity.
+    1: unfold elem_of, elem_of_results in * |-; set_unfold in Hres; cbn in *; cdestruct Hres; eauto.
+    cdestruct |- ***.
+    enough (∃ x0 : A, (∃ x : () * A, x0 = x.2 ∧ x ∈ lr) ∧ x ∈ f x0) by naive_solver.
+    eexists _; split; try eassumption; eexists (_,_); naive_solver.
+  }
 Qed.
 
-#[global] Instance unfold_elem_of_bind_guard `{Decision P} {E A} (e : t E A)
+#[global] Instance unfold_elem_of_bind_guard `{Decision P} {E A} (e : t () E A)
     (err : E) a Q:
   UnfoldElemOf a e Q →
   UnfoldElemOf a (guard_or err P;; e) (P ∧ Q) | 10.
 Proof. tcclean. case_guard; set_solver. Qed.
 
-#[global] Instance unfold_elem_of_bind_guard_discard `{Decision P} {E A} (e : t E A) a Q:
+#[global] Instance unfold_elem_of_bind_guard_discard `{Decision P} {E A} (e : t () E A) a Q:
   UnfoldElemOf a e Q →
   UnfoldElemOf a (guard_discard P;; e) (P ∧ Q) | 10.
 Proof. tcclean. case_guard_discard; set_solver. Qed.
 
-#[global] Instance unfold_elem_of_fmap {E A B} (x : B) (e : t E A) (f : A → B) P:
+#[global] Instance unfold_elem_of_fmap {E A B} (x : B) (e : t () E A) (f : A → B) P:
   (∀ y, UnfoldElemOf y e (P y)) →
   UnfoldElemOf x (f <$> e) (∃ y, P y ∧ x = f y).
-Proof. tcclean. destruct e as [l es]. cbn. set_solver. Qed.
+Proof. tcclean. unfold elem_of, elem_of_results, fmap, fmap_inst.
+ destruct (e ()) as [l es]. cbn. set_unfold. set_solver. Qed.
 
 #[global] Instance unfold_elem_of_mdiscard {E A} (x : A) :
   UnfoldElemOf x (mdiscard : t E A) False.

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -277,27 +277,6 @@ Proof.
   elim l; cdestruct |- ***; set_solver.
 Qed.
 
-#[global] Instance unfold_elem_of_foldr_error {St E A} es (x : St * E) (l : list (res (St * E) (St * A))) :
-  SetUnfoldElemOf x (foldr merge {| results := []; errors := es |} l).(errors) (x ∈ es ∨ (x ∈ (mjoin (errors <$> l)))) | 20.
-Proof.
-  tcclean.
-  elim l; cdestruct |- ***; set_solver.
-Qed.
-
-#[global] Instance unfold_elem_of_mbind_error {St E A B} st (x : St * E) (e : t St E A) (f : A → t St E B) P Q :
-  (∀ y, SetUnfoldElemOf y (e st) (Q y)) →
-  (∀ y, SetUnfoldElemOf y (e st).(errors) (P y)) →
-  SetUnfoldElemOf x ((e ≫= f) st).(errors) (P x ∨ ∃ st' y, Q (st',y) ∧ x ∈ (f y st').(errors)) | 20.
-Proof.
-  tcclean. deintro.
-  unfold mbind, mbind_inst, mbind, res_mbind_inst.
-  destruct (e st) as [l es].
-  set_unfold.
-  enough (x ∈ mjoin (errors <$> map (λ '(st', r), f r st') l) ↔ ∃ (x0 : St) (x1 : A), (x0, x1) ∈ l ∧ x ∈ errors (f x1 x0))
-  by naive_solver.
-  elim l; cdestruct |- *** #CDestrSplitGoal; set_solver.
-Qed.
-
 #[global] Instance unfold_elem_of_bind_guard `{Decision P} {St E A} st (e : t St E A)
     (err : E) a Q:
   UnfoldElemOf a (e st) Q →

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -167,18 +167,6 @@ Definition liftSt_full {St St' E A} (getter : St → St') (setter : St' → St �
 Definition liftSt {St St' E A} (getter : St → St') `{Setter St St' getter} (inner : Exec.t St' E A) : Exec.t St E A :=
   liftSt_full getter (@setv _ _ getter _) inner.
 
-Definition partial_liftSt {St St' E A} (P : St → Prop) `{∀ st, Decision (P st)}
-    (e : E)
-    (getter : ∀ st : St, P st → St') (setter : St' → St → St)
-    (inner : Exec.t St' E A) : Exec.t St E A :=
-  λ st,
-    if decide (P st) is left H_P
-    then let inner_res := inner (getter st H_P) in
-      make ((λ '(st',a), (setter st' st, a)) <$> inner_res.(results))
-           ((λ '(st',a), (setter st' st, a)) <$> inner_res.(errors))
-    else
-      make [] [(st,e)].
-
 #[global] Instance elem_of_results {E A} : ElemOf A (res E A) :=
   λ x r, x ∈ r.(results).
 #[global] Typeclasses Opaque elem_of_results.
@@ -205,10 +193,6 @@ Definition partial_liftSt {St St' E A} (P : St → Prop) `{∀ st, Decision (P s
 (** Takes an option but convert None into an error *)
 Definition error_none {St E A} (e : E) : option A -> t St E A :=
   from_option mret (mthrow e).
-
-(** Takes a list but convert Nil into an error *)
-Definition error_Nil {St E A} (e : E) (l : list A) : t St E (A * list A) :=
-  if l is a :: ar then mret (a,ar) else mthrow e.
 
 (** Takes an option but convert None into a discard *)
 Definition discard_none {St E A} : option A -> t St E A :=

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -114,6 +114,9 @@ Definition to_stateful_result_list `(e : res (St * E) (St * A)) : list (St * res
 Definition to_state_result_list `(e : res (St * E) (St * A)) : list (result St St) :=
   map (Ok ∘ fst) e.(results) ++ map (Error ∘ fst) e.(errors).
 
+Definition success_state_list `(e : res (St * E) (St * A)) : list St :=
+  e.(results).*1.
+
 (** * Base execution monad definitions *)
 
 Definition t {St E A} := St → res (St * E) (St * A).

--- a/Common/Exec.v
+++ b/Common/Exec.v
@@ -315,6 +315,22 @@ Qed.
   UnfoldElemOf x ((mdiscard : t St E A) st) False.
 Proof. tcclean. unfold mdiscard, fmap, fmap_inst; cbn. set_solver. Qed.
 
+#[global] Instance unfold_elem_of_Results {St E A C} `{Elements A C} (s : C) (x : St * A) st P:
+  (∀ y : A, SetUnfoldElemOf y (elements s) (P y)) →
+  UnfoldElemOf x (Results (E := E) s st) (P x.2 ∧ x.1 = st).
+Proof. tcclean. unfold Results. destruct x. set_solver. Qed.
+
+#[global] Instance unfold_elem_of_mcallM_MChoice {St E} st st' (m : MChoice) (v : eff_ret m) :
+  UnfoldElemOf (st, v) (mcallM (Exec.t St E) m st') (st = st').
+Proof.
+  tcclean.
+  destruct m.
+  cbn -[enum] in *.
+  unfold mcallM, choose_inst, enum.
+  destruct fin_finite.
+  set_solver.
+Qed.
+
 #[global] Instance res_unfold_elem_of_mbind {E A B} (x :  B) (e : res E A) (f : A → res E B) P:
   (∀ y, UnfoldElemOf y e (P y)) →
   UnfoldElemOf x (e ≫= f) (∃ y, P y ∧ x ∈ f y) | 20.

--- a/Common/FMon.v
+++ b/Common/FMon.v
@@ -423,6 +423,8 @@ Section FMon.
   (** If the target monad already supports the effect, then there is a trivial
       handler *)
   Definition mcall_fHandler `{MC : !MCall Eff M} : fHandler M := mcallM M.
+  #[export] Typeclasses Transparent mcall_fHandler.
+  #[global] Arguments mcall_fHandler {_ _} _ /.
 
   (** Free monad interpret: Interprets a free monad over Eff in an arbitrary monad, using a handler *)
   Fixpoint finterp `{MR: MRet M, MB: MBind M} (handler : fHandler M)

--- a/Extraction/dune
+++ b/Extraction/dune
@@ -10,7 +10,7 @@
                      decidable definitions Effects Exec fin0 finite fin_maps Fin
                      FMon gmap Interface list0 List list_numbers listset mapset
                      Nat numbers option propset RecordSet
-                     sets Specif StateT String0 strings ConcurrencyInterfaceTypes
+                     sets Specif String0 strings ConcurrencyInterfaceTypes
                      Instances Values MachineWord FromSail ConcurrencyInterface
                      System_types
                      TermModels vector0 VectorDef Vector)


### PR DESCRIPTION
This is still very much unfinished. I never fully fixed up the promising part. Also I need to clean up the Exec.v file: Make res/t record visually more separated, use Exec.res monadic operations in Exec.t.