### PR TITLE
X86-TSO: modify operational model and update ISA model

### DIFF
--- a/ArchSemX86/OperationalX86TSO.v
+++ b/ArchSemX86/OperationalX86TSO.v
@@ -217,9 +217,9 @@ Section Model.
     (* Ensure thread can acquire lock: a thread (including thread tid) might already have the lock*)
     lock_status ← mget lock;
     guard_discard (lock_status = None);;
-    (* Ensure thread can acquire lock: store buffer might not be empty.
-       Hence eagerly empty buffer. Can do this as no other thread has lock *)
-    empty_write_buffer tid;;
+    (* Ensure thread can acquire lock: store buffer needs to be empty *)
+    '(buffer_is_empty : bool) ← mget (buffer_empty tid);
+    guard_discard buffer_is_empty;;
     (* Acquire lock *)
     mSet (acquire_lock tid).
 
@@ -228,11 +228,12 @@ Section Model.
 
   Definition release_lock_conditional (tid : fin threads) :
       Exec.t mstate string unit :=
-    (* Make sure we have the lock before releasing it *)
+    (* Ensure thread can release lock: make sure we have the lock*)
     state ← mGet;
     guard_discard (thread_has_lock tid state);;
-    (* Empty write buffer (eager) (other requirement for releasing lock) *)
-    empty_write_buffer tid;;
+    (* Ensure thread can release lock: ensure that the write buffer is empty *)
+    '(buffer_is_empty : bool) ← mget (buffer_empty tid);
+    guard_discard buffer_is_empty;;
     (* Release lock *)
     mSet (release_lock tid).
 
@@ -287,22 +288,22 @@ Section Model.
         (* Handle atomic case (release lock) *)
         (if is_atomic_rmw macc then
           if eager then
-            (* Must discard outcome if eager, as release_lock_conditional requires
-              the store buffer to be emptied to complete *)
+            (* Must discard outcome if eager, as we need an emptied write buffer to 
+              release the lock *)
             mdiscard
-          else release_lock_conditional tid
+          else 
+            empty_write_buffer tid;;
+            release_lock_conditional tid
         else mret ());;
         mret (Ok ())
     | MemWrite _ _ _ => mthrow "Unsupported MemWrite"
     | Barrier Barrier_MFENCE =>
         (* Cannot eagerly perform memory barriers that do something*)
         guard_discard (negb eager);;
-
-        (* Write buffer (of thread tid) must be emptied before this instruction
-           can complete. *)
-        is_blocked ← mget (blocked tid);
-        guard_discard (negb is_blocked);;
-        empty_write_buffer tid
+        (* Write buffer (of thread tid) must be empty for this instruction to complete. *)
+        '(buffer_is_empty : bool) ← mget (buffer_empty tid);
+        guard_discard buffer_is_empty;;
+        mret ()
     | Barrier _ => mret ()
     | GenericFail msg => mthrow msg
     | _ => mthrow "Unsupported outcome".
@@ -351,6 +352,9 @@ Section Model.
     tid ← mchoosef;
     flush_transition ← mchoosef;
     if (flush_transition : bool) then
+      (* Discard if lock is not free *)
+      lock_status ← mget lock;
+      guard_discard (lock_status = None);;
       (* This function discards if there is nothing to flush. *)
       flush_one_item_buffer tid;;
       mret None

--- a/ArchSemX86/OperationalX86TSO.v
+++ b/ArchSemX86/OperationalX86TSO.v
@@ -54,7 +54,7 @@ Section Model.
   (** * Types *)
 
   (** A memory entry in a write-buffer *)
-  Record addr_val := {
+  Record buffer_entry := {
       addr: address;
       size: N; (* IN BYTES *)
       val: bv (8 * size)
@@ -67,7 +67,7 @@ Section Model.
 
       (* Store buffer for each thread. Each buffer is a list of address-value
         tuples, oldest first *)
-      buf : vec (list addr_val) threads;
+      buf : vec (list buffer_entry) threads;
 
       (* Global machine lock, indicating when some thread has exclusive access to
         memory *)
@@ -108,7 +108,7 @@ Section Model.
   Definition all_buffers_empty (state : mstate) : bool :=
     bool_decide (∀ t : fin threads, buffer_empty t state).
 
-  Fixpoint read_from_write_buffer_inner (rev_buffer : list addr_val)
+  Fixpoint read_from_write_buffer_inner (rev_buffer : list buffer_entry)
       (goal_addr: address) (goal_size : N) :
       Exec.t mstate string (option (bv (8 * goal_size))) :=
     (* Allow a direct match to be store-forwarded
@@ -182,7 +182,7 @@ Section Model.
       read ← othrow ("Memory not found at " ++ pretty addr)%string opt;
       mret read.
 
-  Fixpoint write_buffer_to_mem (buffer: list addr_val) (tid: fin threads) :
+  Fixpoint write_buffer_to_mem (buffer: list buffer_entry) (tid: fin threads) :
       Exec.t mstate string unit :=
     match buffer with
     | [] => mret ()

--- a/ArchSemX86/tests/X86SeqModelTest.v
+++ b/ArchSemX86/tests/X86SeqModelTest.v
@@ -165,9 +165,7 @@ Module STRLDR. (* MOV [EAX + 0x100], ECX; MOV EAX, [EAX + 0x100] at 0x500, using
   Qed.
 End STRLDR.
 
-Module Factorial. (* https://godbolt.org/z/GWcWjTrWc, 
-  but with opcode 83 instructions changed to opcode 81 instructions,
-  and with shifted instruction addresses *)
+Module Factorial. (* https://godbolt.org/z/GWcWjTrWc, but with shifted instruction addresses *)
   Definition init_reg : registerMap :=
     common_init_regs
     |> reg_insert rip 0x500
@@ -179,22 +177,22 @@ Module Factorial. (* https://godbolt.org/z/GWcWjTrWc,
 
   Definition init_mem : memoryMap:=
     ∅
-    |> mem_insert 0x500 1 0x51              (* push rcx (return address) = 0x5 @ 0b0 @ 0b001 *)
-    |> mem_insert 0x501 1 0x55              (* push rbp *)
-    |> mem_insert 0x502 3 0xe58948          (* mov rbp, rsp *)
-    |> mem_insert 0x505 7 0x00000010ec8148  (* sub rsp, 0x10 *)
-    |> mem_insert 0x50c 3 0xfc7d89          (* mov DWORD PTR [rbp-0x4], edi *)
-    |> mem_insert 0x50f 7 0x00000000fc7d81  (* cmp DWORD PTR [rbp-0x4], 0x0 *)
-    |> mem_insert 0x516 2 0x0775            (* jne 0x51f *)
-    |> mem_insert 0x518 5 0x00000001b8      (* mov eax, 0x1 *) 
-    |> mem_insert 0x51d 2 0x14eb            (* jmp 0x533 *)
-    |> mem_insert 0x51f 3 0xfc458b          (* mov eax, DWORD PTR [rbp-0x4] *) 
-    |> mem_insert 0x522 6 0x00000001e881    (* sub eax, 0x1 *) 
-    |> mem_insert 0x528 2 0xc789            (* mov edi, eax *)
-    |> mem_insert 0x52a 5 0xffffffd2e8      (* call 0x501 (relative rip change is -2e) *)
-    |> mem_insert 0x52f 4 0xfc45af0f        (* imul eax, DWORD PTR [rbp-0x4] *)
-    |> mem_insert 0x533 1 0xc9              (* leave *)
-    |> mem_insert 0x534 1 0xc3              (* ret *)
+    |> mem_insert 0x500 1 0x51          (* push rcx (return address) = 0x5 @ 0b0 @ 0b001 *)
+    |> mem_insert 0x501 1 0x55          (* push rbp *)
+    |> mem_insert 0x502 3 0xe58948      (* mov rbp, rsp *)
+    |> mem_insert 0x505 4 0x10ec8348    (* sub rsp, 0x10 *)
+    |> mem_insert 0x509 3 0xfc7d89      (* mov DWORD PTR [rbp-0x4], edi *)
+    |> mem_insert 0x50c 4 0x00fc7d83    (* cmp DWORD PTR [rbp-0x4], 0x0 *)
+    |> mem_insert 0x510 2 0x0775        (* jne 0x519 (0x07 relative)*)
+    |> mem_insert 0x512 5 0x00000001b8  (* mov eax, 0x1 *) 
+    |> mem_insert 0x517 2 0x11eb        (* jmp 0x52a (0x11 relative) *)
+    |> mem_insert 0x519 3 0xfc458b      (* mov eax, DWORD PTR [rbp-0x4] *) 
+    |> mem_insert 0x51c 3 0x01e883      (* sub eax, 0x1 *) 
+    |> mem_insert 0x51f 2 0xc789        (* mov edi, eax *)
+    |> mem_insert 0x521 5 0xffffffdbe8  (* call 0x501 (relative rip change is -26) *)
+    |> mem_insert 0x526 4 0xfc45af0f    (* imul eax, DWORD PTR [rbp-0x4] *)
+    |> mem_insert 0x52a 1 0xc9          (* leave *)
+    |> mem_insert 0x52b 1 0xc3          (* ret *)
 
     |> mem_insert 0x1235 256 0. (* Memory need to exist to be written to *)
 

--- a/coq-archsem-x86.opam.locked
+++ b/coq-archsem-x86.opam.locked
@@ -138,7 +138,7 @@ pin-depends: [
   ]
   [
     "coq-sail-tiny-x86.dev"
-    "git+https://github.com/rems-project/sail-tiny-x86.git#840cbb7"
+    "git+https://github.com/rems-project/sail-tiny-x86.git#a37d128"
   ]
   [
     "coq-stdpp.1.12.0"


### PR DESCRIPTION
Small changes
- Change write buffer entry type from addr_val to buffer_entry
- Modify operational to match existing rules more. Not eagerly emptying the buffer in places decreases the number of redundant execution paths.
- Update ISA model
- Update x86 sequential factorial test to use more convenient instruction opcodes