### PR TITLE
CLI: add profiles in config

### DIFF
--- a/cli/bin/main.ml
+++ b/cli/bin/main.ml
@@ -63,7 +63,7 @@ type format =
     Recognised extensions are:
     - .archsem.toml for ArchSem format TOML tests
     - .litmus.toml for Isla-style litmus tests *)
-let parse_testfile fmt filename =
+let parse_testfile ~mode fmt filename =
   assert (Filename.extension filename = ".toml");
   let fmt =
     match fmt with
@@ -85,7 +85,7 @@ let parse_testfile fmt filename =
   | Archsem -> Parser.parse_to_testrepr toml
   | Isla ->
       toml |> Isla.Ir.of_toml |> Isla.Normalize.apply
-      |> Isla.Converter.to_testrepr
+      |> Isla.Converter.to_testrepr ~mode
 
 let get_toml_files dir =
   if Sys.file_exists dir && Sys.is_directory dir then
@@ -188,7 +188,7 @@ let format_term =
 let cmd_seq =
   let run =
     let+ files = path_and_conf_term and+ fmt = format_term in
-    let parse = parse_testfile fmt in
+    let parse = parse_testfile ~mode:"seq" fmt in
     match Config.get_arch () with
     | Arm ->
         run_tests "arm-seq"
@@ -209,7 +209,7 @@ let cmd_seq =
 let cmd_ump =
   let run =
     let+ files = path_and_conf_term and+ fmt = format_term in
-    let parse = parse_testfile fmt in
+    let parse = parse_testfile ~mode:"ump" fmt in
     assert (Config.get_arch () = Arch_id.Arm);
     run_tests "ump"
       (ArmRunner.run_litmus_test ~parse Arm.(umProm_model tiny_isa))
@@ -251,7 +251,7 @@ let cmd_vmp =
     let+ files = path_and_conf_term
     and+ bbm_param = bbm_mode
     and+ fmt = format_term in
-    let parse = parse_testfile fmt in
+    let parse = parse_testfile ~mode:"vmp" fmt in
     assert (Config.get_arch () = Arch_id.Arm);
     run_tests "vmp"
       (ArmRunner.run_litmus_test ~parse (vmProm_model ~bbm_param tiny_isa))
@@ -276,7 +276,7 @@ let cmd_tso =
     and+ fmt = format_term
     and+ no_eager = no_eager in
     let allow_eager = not no_eager in
-    let parse = parse_testfile fmt in
+    let parse = parse_testfile ~mode:"x86_tso" fmt in
     assert (Config.get_arch () = Arch_id.X86);
     run_tests "tso"
       (X86Runner.run_litmus_test ~parse X86.(op_model ~allow_eager tiny_isa))
@@ -339,7 +339,7 @@ let cmd_convert =
     let+ files = path_and_conf_term
     and+ fmt = format_term
     and+ output = output_term in
-    let parse = parse_testfile fmt in
+    let parse = parse_testfile ~mode:"seq" fmt in
     convert files parse output
   in
   let info =

--- a/cli/lib/isla/converter.ml
+++ b/cli/lib/isla/converter.ml
@@ -61,11 +61,20 @@ let pc_reg arch =
   | Litmus.Arch_id.Arm -> Archsem.Arm.Reg.to_string Archsem.Arm.Reg.pc
   | Litmus.Arch_id.X86 -> Archsem.X86.Reg.to_string Archsem.X86.Reg.pc
 
-let register_defaults () =
+let register_defaults ~mode () =
   let config = Config.get () in
-  Otoml.find_or ~default:[] config
-    (Otoml.get_table_values regval_of_toml)
-    ["registers"; "defaults"]
+  let base =
+    Otoml.find_or ~default:[] config
+      (Otoml.get_table_values regval_of_toml)
+      ["registers"; "defaults"]
+  in
+  let overlay =
+    Otoml.find_or ~default:[] config
+      (Otoml.get_table_values regval_of_toml)
+      [mode; "registers"; "defaults"]
+  in
+  let has name = List.exists (fun (k, _) -> k = name) overlay in
+  List.filter (fun (k, _) -> not (has k)) base @ overlay
 
 let instruction_step () =
   let width =
@@ -159,7 +168,7 @@ let z_of_value syms = function
   | Ir.Int z -> z
   | Ir.Sym sym -> Z.of_int (Symbols.resolve syms sym)
 
-let build_registers syms ~arch pc (thread : Ir.thread) =
+let build_registers ~mode syms ~arch pc (thread : Ir.thread) =
   let pc_entry = (pc_reg arch, RegValGen.Number (Z.of_int pc)) in
   let used_regs =
     List.map
@@ -170,7 +179,7 @@ let build_registers syms ~arch pc (thread : Ir.thread) =
   let default_regs =
     List.filter_map
       (fun (reg, value) -> if has reg then None else Some (reg, value))
-      (register_defaults ())
+      (register_defaults ~mode ())
   in
   (pc_entry :: used_regs) @ default_regs
 
@@ -187,7 +196,7 @@ let build_data_memory syms sym addr init_value =
   Bytes.blit_string bits 0 data 0 (min mem_size (String.length bits));
   {Testrepr.addr; step = mem_size; data; sym = Some sym; kind = Testrepr.Data}
 
-let to_testrepr (ir : Ir.t) : Testrepr.t =
+let to_testrepr ~mode (ir : Ir.t) : Testrepr.t =
   let syms = Symbols.empty () in
   List.iter (Symbols.alloc_sym syms) ir.symbolic;
   let encoded_threads =
@@ -203,7 +212,7 @@ let to_testrepr (ir : Ir.t) : Testrepr.t =
   let registers =
     List.map
       (fun (thread, _, code_addr) ->
-         build_registers syms ~arch:ir.arch code_addr thread
+         build_registers ~mode syms ~arch:ir.arch code_addr thread
        )
       encoded_threads
   in

--- a/cli/tests/unit/isla/converter_test.ml
+++ b/cli/tests/unit/isla/converter_test.ml
@@ -48,7 +48,8 @@ module X86Runner = Runner.Make (X86)
 module RegValGen = Archsem.RegValGen
 
 let convert toml =
-  toml |> Isla.Ir.of_toml |> Isla.Normalize.apply |> Isla.Converter.to_testrepr
+  toml |> Isla.Ir.of_toml |> Isla.Normalize.apply
+  |> Isla.Converter.to_testrepr ~mode:"seq"
 
 let n i = RegValGen.Number (Z.of_int i)
 
@@ -58,7 +59,7 @@ let expected_regs ~arch ~pc overrides =
   let defaults =
     List.filter_map
       (fun (name, value) -> if has name then None else Some (name, value))
-      (Isla.Converter.register_defaults ())
+      (Isla.Converter.register_defaults ~mode:"seq" ())
   in
   ((pc_reg, n pc) :: overrides) @ defaults
 

--- a/config/Arm.toml
+++ b/config/Arm.toml
@@ -6,6 +6,10 @@ fuel = 1000
 [vmp]
 bbm = "off"
 
+[vmp.registers.defaults]
+TCR_EL1 = 0
+ID_AA64MMFR1_EL1 = 0
+
 [assembler]
 assemble = "llvm-mc -triple=aarch64 -mattr=+lse,+rcpc --assemble --filetype=obj"
 extract = "llvm-objcopy -O binary"


### PR DESCRIPTION
`[registers.defaults]` is shared across all models, so anything vmp wants to set (e.g. `ID_AA64MMFR1_EL1` to
  select FEAT_ETS / ETS2 translation semantics) would leak into seq or ump. This PR lets each model merge its own `[<mode>.registers.defaults]`.