### PR TITLE
CLI: Add function term evaluation

### DIFF
--- a/cli/bin/main.ml
+++ b/cli/bin/main.ml
@@ -59,35 +59,52 @@ type format =
   | Archsem
   | Isla
 
+(** Guess a test format based on filename extension *)
+let guess_format (fmt : format option) (filename : string) : format =
+  match fmt with
+  | Some fmt -> fmt
+  | None -> (
+      let name = Filename.remove_extension filename in
+      let ext = Filename.extension name in
+      match ext with
+      | ".litmus" -> Isla
+      | ".archsem" -> Archsem
+      | _ ->
+          Error.fatal
+            "Could not guess test format from filename %s. Only .archsem.toml \
+             and .litmus.toml are supported"
+             filename
+    )
+
 (** Parse test files with the specified [fmt]. Guess based on the extension if [None].
     Recognised extensions are:
     - .archsem.toml for ArchSem format TOML tests
-    - .litmus.toml for Isla-style litmus tests *)
-let parse_testfile (fmt : format option) (filename : string) =
-  Error.assert_fatal
-    (Filename.extension filename = ".toml")
-    "Input file name %s is not ending in .toml" filename;
-  let fmt =
+    - .litmus.toml for Isla-style litmus tests
+
+    Print an error message and return [Exit] if this can't produce a valid
+    [Testrepr.t] *)
+let parse_testfile (fmt : format option) (filename : string) : Testrepr.t =
+  try
+    let fmt = guess_format fmt filename in
+    let toml = Toml.Parser.from_file filename in
     match fmt with
-    | Some fmt -> fmt
-    | None -> (
-        let name = Filename.remove_extension filename in
-        let ext = Filename.extension name in
-        match ext with
-        | ".litmus" -> Isla
-        | ".archsem" -> Archsem
-        | _ ->
-            failwith
-              "Could not guess test format from filename. Only .archsem.toml and \
-               .litmus.toml are supported"
-      )
-  in
-  let toml = Toml.Parser.from_file filename in
-  match fmt with
-  | Archsem -> Parser.parse_to_testrepr toml
-  | Isla ->
-      toml |> Isla.Ir.of_toml |> Isla.Normalize.apply
-      |> Isla.Converter.to_testrepr
+    | Archsem -> Parser.parse_to_testrepr toml
+    | Isla ->
+        toml |> Isla.Ir.of_toml |> Isla.Normalize.apply
+        |> Isla.Converter.to_testrepr
+  with
+  | Toml.Parse_error (pos, msg) ->
+      Error.parse_error filename pos "%s" msg;
+      raise Exit
+  | Toml.Path_error (path, Toml.FieldMissing field) ->
+      Error.toml_error filename path "Missing field: %s" field;
+      raise Exit
+  | Toml.Path_error (path, Toml.GenError msg) ->
+      Error.toml_error filename path "%s" msg;
+      raise Exit
+  | Isla.Converter.Term_eval_error (path, msg) ->
+      Error.eval_error filename path "%s" msg;
+      raise Exit
 
 let get_toml_files dir =
   if Sys.file_exists dir && Sys.is_directory dir then
@@ -323,11 +340,13 @@ let convert files parse output =
   );
   List.iter
     (fun filename ->
-       let output = convert_output filename output in
-       if Sys.file_exists output then
-         Printf.ksprintf failwith "Target file already exists: %s" output;
-       let t = parse filename in
-       Litmus.Printer.to_file output t
+       try
+         let output = convert_output filename output in
+         if Sys.file_exists output then
+           Printf.ksprintf failwith "Target file already exists: %s" output;
+         let t = parse filename in
+         Litmus.Printer.to_file output t
+       with Exit -> exit 1
      )
     files
 

--- a/cli/lib/isla/bv_fns.ml
+++ b/cli/lib/isla/bv_fns.ml
@@ -38,51 +38,91 @@
 (*                                                                            *)
 (******************************************************************************)
 
-(** This module is here to help error handling *)
+(** Bitvector functions: bvand, bvor, bvxor, bvshl, bvlshr, extz, exts. *)
 
-(** Raise a fatal error with [code], adds "archsem: error" in front*)
-let fatal ?(code = 1) fmt =
-  Printf.eprintf "archsem: %s%sfatal error:%s " Terminal.red Terminal.bold
-    Terminal.reset;
-  Printf.kfprintf (fun _ -> Printf.eprintf "\n"; exit code) stderr fmt
+let int_of_bit_arg name arg value =
+  if Z.sign value < 0 then
+    Litmus.Error.failwith "function: %s: argument %s must be non-negative" name
+      arg;
+  match Z.to_int value with
+  | n -> n
+  | exception Z.Overflow ->
+      Litmus.Error.failwith "function: %s: argument %s is too large" name arg
 
-let assert_fatal ?(code = 1) (cond : bool) fmt =
-  if cond then Printf.ikfprintf (fun _ -> ()) stderr fmt else fatal ~code fmt
+(** List of bitvector primitive functions
 
-let parse_error file loc fmt =
-  Printf.eprintf "archsem: %s%sparse error:%s\n" Terminal.red Terminal.bold
-    Terminal.reset;
-  ( match loc with
-  | Some (line, col) ->
-      Printf.eprintf "%sFile %s, line %d, character %d:%s\n" Terminal.bold file
-        line col Terminal.reset
-  | None -> Printf.eprintf "%sFile %s:%s\n" Terminal.bold file Terminal.reset
-  );
-  Printf.kfprintf (fun fmt -> Printf.fprintf fmt "\n") stderr fmt
-
-let toml_error file path fmt =
-  Printf.eprintf "archsem: %s%sTOML error:%s\n" Terminal.red Terminal.bold
-    Terminal.reset;
-  if path == [] then
-    Printf.eprintf "%sFile \"%s\":%s\n" Terminal.bold file Terminal.reset
-  else
-    Printf.eprintf "%sFile \"%s\", path \"%s\":%s\n" Terminal.bold file
-      (String.concat "." path) Terminal.reset;
-  Printf.kfprintf (fun fmt -> Printf.fprintf fmt "\n") stderr fmt
-
-let eval_error file path fmt =
-  Printf.eprintf "archsem: %s%seval error:%s\n" Terminal.red Terminal.bold
-    Terminal.reset;
-  if path == [] then
-    Printf.eprintf "%sFile \"%s\":%s\n" Terminal.bold file Terminal.reset
-  else
-    Printf.eprintf "%sFile \"%s\", path \"%s\":%s\n" Terminal.bold file
-      (String.concat "." path) Terminal.reset;
-  Printf.kfprintf (fun fmt -> Printf.fprintf fmt "\n") stderr fmt
-
-let model_error test msg =
-  Printf.eprintf "archsem: %s%smodel error:%s\n" Terminal.red Terminal.bold
-    Terminal.reset;
-  Printf.eprintf "%sTest \"%s\":%s\n%s\n" Terminal.bold test Terminal.reset msg
-
-let failwith fmt = Printf.ksprintf failwith fmt
+    Any error during evaluation should be reported with [Failure] which will be
+    converted into a [eval_error] in [Term.eval] *)
+let functions : (string * Fn_registry.fn_spec) list =
+  [ ( "bvand",
+      { params = ["a"; "b"];
+        eval =
+          (fun args ->
+            match args with
+            | [a; b] -> Z.logand a b
+            | _ -> Fn_registry.arity_error "bvand" 2 (List.length args)
+          )
+      }
+    );
+    ( "bvor",
+      { params = ["a"; "b"];
+        eval =
+          (fun args ->
+            match args with
+            | [a; b] -> Z.logor a b
+            | _ -> Fn_registry.arity_error "bvor" 2 (List.length args)
+          )
+      }
+    );
+    ( "bvxor",
+      { params = ["a"; "b"];
+        eval =
+          (fun args ->
+            match args with
+            | [a; b] -> Z.logxor a b
+            | _ -> Fn_registry.arity_error "bvxor" 2 (List.length args)
+          )
+      }
+    );
+    ( "bvshl",
+      { params = ["a"; "b"];
+        eval =
+          (fun args ->
+            match args with
+            | [a; b] -> Z.shift_left a (int_of_bit_arg "bvshl" "b" b)
+            | _ -> Fn_registry.arity_error "bvshl" 2 (List.length args)
+          )
+      }
+    );
+    ( "bvlshr",
+      { params = ["a"; "b"];
+        eval =
+          (fun args ->
+            match args with
+            | [a; b] -> Z.shift_right a (int_of_bit_arg "bvlshr" "b" b)
+            | _ -> Fn_registry.arity_error "bvlshr" 2 (List.length args)
+          )
+      }
+    );
+    ( "extz",
+      { params = ["bits"; "len"];
+        eval =
+          (fun args ->
+            match args with
+            | [bits; len] ->
+                ignore (int_of_bit_arg "extz" "len" len);
+                bits
+            | _ -> Fn_registry.arity_error "extz" 2 (List.length args)
+          )
+      }
+    );
+    ( "exts",
+      { params = ["bits"; "len"];
+        eval =
+          (fun _ ->
+            Litmus.Error.failwith
+              "exts is not support because of integer semantics"
+          )
+      }
+    )
+  ]

--- a/cli/lib/isla/converter.ml
+++ b/cli/lib/isla/converter.ml
@@ -90,9 +90,27 @@ let init_bytes_of_value mem_size sym value =
   Bytes.blit_string bits 0 data 0 (min mem_size (String.length bits));
   data
 
-let data_symbol_of_value ~resolve_sym mem_size sym value =
+type term_eval_context =
+  | Location_init of string
+  | Register_init of int * string
+  | Final_assertion
+
+exception Term_eval_error of string list * string
+
+let term_eval_context_path = function
+  | Location_init sym -> ["locations"; sym]
+  | Register_init (tid, reg) -> ["thread"; string_of_int tid; "init"; reg]
+  | Final_assertion -> ["final"; "assertion"]
+
+let eval_term ~context ~resolve_sym term =
+  try Term.eval ~resolve_sym term
+  with Failure msg ->
+    raise (Term_eval_error (term_eval_context_path context, msg))
+
+let data_symbol_of_value ~context ~resolve_sym mem_size sym value =
   { Assembler.name = sym;
-    init_bytes = init_bytes_of_value mem_size sym (Term.eval ~resolve_sym value)
+    init_bytes =
+      init_bytes_of_value mem_size sym (eval_term ~context ~resolve_sym value)
   }
 
 let to_assembly_input (ir : Ir.t) : Assembler.assembly_input =
@@ -115,7 +133,9 @@ let to_assembly_input (ir : Ir.t) : Assembler.assembly_input =
          in
          (* A symbol-valued initializer needs the post-link symbol address, but
             the assembler only needs the block size to compute layout here. *)
-         data_symbol_of_value ~resolve_sym:(fun _ -> 0) mem_size sym init_value
+         data_symbol_of_value ~context:(Location_init sym)
+           ~resolve_sym:(fun _ -> 0)
+           mem_size sym init_value
        )
       ir.symbolic
   in
@@ -141,7 +161,7 @@ let resolve_data_symbols
        let init_value =
          List.assoc_opt sym ir.locations |> Option.value ~default:Term.zero
        in
-       data_symbol_of_value
+       data_symbol_of_value ~context:(Location_init sym)
          ~resolve_sym:(Assembler.resolve_symbol asm_result)
          mem_size sym init_value
      )
@@ -207,7 +227,8 @@ let build_registers
        let used_regs =
          List.map
            (fun (reg, value) ->
-              (reg, RegValGen.Number (Term.eval ~resolve_sym value))
+              let context = Register_init (thread.tid, reg) in
+              (reg, RegValGen.Number (eval_term ~context ~resolve_sym value))
             )
            thread.init
        in
@@ -258,5 +279,8 @@ let to_testrepr (ir : Ir.t) : Testrepr.t =
     memory;
     term_cond;
     kind = ir.kind;
-    final = Assertion.map_cst (Term.eval ~resolve_sym) ir.assertion
+    final =
+      Assertion.map_cst
+        (eval_term ~context:Final_assertion ~resolve_sym)
+        ir.assertion
   }

--- a/cli/lib/isla/fn_registry.ml
+++ b/cli/lib/isla/fn_registry.ml
@@ -38,51 +38,49 @@
 (*                                                                            *)
 (******************************************************************************)
 
-(** This module is here to help error handling *)
+(** Registry for evaluating named functions in Isla terms.
+    Defines the [fn_spec] type and lookup/evaluation helpers.
 
-(** Raise a fatal error with [code], adds "archsem: error" in front*)
-let fatal ?(code = 1) fmt =
-  Printf.eprintf "archsem: %s%sfatal error:%s " Terminal.red Terminal.bold
-    Terminal.reset;
-  Printf.kfprintf (fun _ -> Printf.eprintf "\n"; exit code) stderr fmt
+    Any error during evaluation should be reported with [Failure] which will be
+    converted into a [eval_error] in [Term.eval] *)
 
-let assert_fatal ?(code = 1) (cond : bool) fmt =
-  if cond then Printf.ikfprintf (fun _ -> ()) stderr fmt else fatal ~code fmt
+type fn_spec =
+  { params : string list;
+    eval : Z.t list -> Z.t
+  }
 
-let parse_error file loc fmt =
-  Printf.eprintf "archsem: %s%sparse error:%s\n" Terminal.red Terminal.bold
-    Terminal.reset;
-  ( match loc with
-  | Some (line, col) ->
-      Printf.eprintf "%sFile %s, line %d, character %d:%s\n" Terminal.bold file
-        line col Terminal.reset
-  | None -> Printf.eprintf "%sFile %s:%s\n" Terminal.bold file Terminal.reset
-  );
-  Printf.kfprintf (fun fmt -> Printf.fprintf fmt "\n") stderr fmt
+let arity_error name expected actual =
+  Litmus.Error.failwith "function: %s: expected %d arguments, got %d" name
+    expected actual
 
-let toml_error file path fmt =
-  Printf.eprintf "archsem: %s%sTOML error:%s\n" Terminal.red Terminal.bold
-    Terminal.reset;
-  if path == [] then
-    Printf.eprintf "%sFile \"%s\":%s\n" Terminal.bold file Terminal.reset
-  else
-    Printf.eprintf "%sFile \"%s\", path \"%s\":%s\n" Terminal.bold file
-      (String.concat "." path) Terminal.reset;
-  Printf.kfprintf (fun fmt -> Printf.fprintf fmt "\n") stderr fmt
+let eval_fn ~fns name args =
+  match List.assoc_opt name fns with
+  | Some spec -> spec.eval args
+  | None -> Litmus.Error.failwith "function: unknown %s/%d" name (List.length args)
 
-let eval_error file path fmt =
-  Printf.eprintf "archsem: %s%seval error:%s\n" Terminal.red Terminal.bold
-    Terminal.reset;
-  if path == [] then
-    Printf.eprintf "%sFile \"%s\":%s\n" Terminal.bold file Terminal.reset
-  else
-    Printf.eprintf "%sFile \"%s\", path \"%s\":%s\n" Terminal.bold file
-      (String.concat "." path) Terminal.reset;
-  Printf.kfprintf (fun fmt -> Printf.fprintf fmt "\n") stderr fmt
+let align_kwargs name spec kwargs =
+  let bindings =
+    List.fold_left
+      (fun bindings (arg, value) ->
+         if not (List.mem arg spec.params) then
+           Litmus.Error.failwith "function: %s: unknown argument %s" name arg
+         else if List.mem_assoc arg bindings then
+           Litmus.Error.failwith "function: %s: duplicate argument %s" name arg
+         else (arg, value) :: bindings
+       )
+      [] kwargs
+  in
+  List.map
+    (fun param ->
+       match List.assoc_opt param bindings with
+       | Some value -> value
+       | None ->
+           Litmus.Error.failwith "function: %s: missing argument %s" name param
+     )
+    spec.params
 
-let model_error test msg =
-  Printf.eprintf "archsem: %s%smodel error:%s\n" Terminal.red Terminal.bold
-    Terminal.reset;
-  Printf.eprintf "%sTest \"%s\":%s\n%s\n" Terminal.bold test Terminal.reset msg
-
-let failwith fmt = Printf.ksprintf failwith fmt
+let eval_kwfn ~fns name kwargs =
+  match List.assoc_opt name fns with
+  | Some spec -> spec.eval (align_kwargs name spec kwargs)
+  | None ->
+      Litmus.Error.failwith "function: unknown %s/%d" name (List.length kwargs)

--- a/cli/lib/isla/ir.ml
+++ b/cli/lib/isla/ir.ml
@@ -75,10 +75,15 @@ type t =
 let parse_term : Toml.t -> Term.t = function
   | TomlInteger i -> Term.Const i
   | TomlString s -> (
-    try Term.Const (Z.of_string s) with Invalid_argument _ -> Term.Sym s
-  )
+      let lexbuf = Lexing.from_string s in
+      try Parser.binding Lexer.token lexbuf
+      with Parser.Error ->
+        Toml.error "term parse error at position %d in: %s"
+          lexbuf.lex_curr_p.pos_cnum s
+    )
   | value ->
-      Toml.error "Isla value is invalid, should be int or string, but is: %s"
+      Toml.error
+        "Isla value is invalid, should be int or string expression, but is: %s"
         (Toml.Printer.to_string value)
 
 let is_meta_key k = String.starts_with ~prefix:"__isla" k

--- a/cli/lib/isla/lexer.mll
+++ b/cli/lib/isla/lexer.mll
@@ -57,6 +57,7 @@ rule token = parse
   | '=' { EQ }
   | '*' { STAR }
   | ':' { COLON }
+  | ',' { COMMA }
   | "true" { TRUE }
   | "false" { FALSE }
   | '0' ['x' 'X'] hex+ as s { NUM (Z.of_string s) }

--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -46,6 +46,7 @@
 %token <string> IDENT
 %token LPAREN "("
 %token RPAREN ")"
+%token COMMA ","
 %token AND "&"
 %token OR "|"
 %token NOT "~"
@@ -60,11 +61,15 @@
 %nonassoc NOT
 
 %start <Term.t Litmus.Assertion.expr> assertion
+%start <Term.t> binding
 
 %%
 
 assertion:
   | e = prop; EOF { e }
+
+binding:
+  | v = term; EOF { v }
 
 prop:
   | e1 = prop; "|"; e2 = prop { Or [e1; e2] }
@@ -85,4 +90,9 @@ loc:
 
 term:
   | v = NUM { Term.Const v }
+  | f = IDENT; "("; args = separated_list(",", term); ")" { Term.Fn (f, args) }
+  | f = IDENT; "("; kw = separated_nonempty_list(",", kw_arg); ")" { Term.KwFn (f, kw) }
   | s = IDENT { Term.Sym s }
+
+kw_arg:
+  | k = IDENT; "="; v = term { (k, v) }

--- a/cli/lib/isla/term.ml
+++ b/cli/lib/isla/term.ml
@@ -43,9 +43,20 @@
 type t =
   | Const of Z.t
   | Sym of string
+  | Fn of string * t list
+  | KwFn of string * (string * t) list
 
 let zero = Const Z.zero
 
-let eval ~resolve_sym = function
+(* More functions can be appended. *)
+let builtins = Bv_fns.functions
+
+let rec eval ~resolve_sym = function
   | Const z -> z
   | Sym sym -> Z.of_int (resolve_sym sym)
+  | Fn (name, args) ->
+      let evaluated = List.map (eval ~resolve_sym) args in
+      Fn_registry.eval_fn ~fns:builtins name evaluated
+  | KwFn (name, kwargs) ->
+      let evaluated = List.map (fun (k, v) -> (k, eval ~resolve_sym v)) kwargs in
+      Fn_registry.eval_kwfn ~fns:builtins name evaluated

--- a/cli/lib/litmus/runner.ml
+++ b/cli/lib/litmus/runner.ml
@@ -122,17 +122,6 @@ module Make (Arch : Archsem.Arch) = struct
   let run_test_file ~parse ~short model filename =
     let name = Filename.basename filename in
     if not (Sys.file_exists filename) then Error.fatal "file not found: %s" name;
-    let test =
-      try parse filename with
-      | Toml.Parse_error (pos, msg) ->
-          Error.parse_error filename pos "%s" msg;
-          raise Exit
-      | Toml.Path_error (path, FieldMissing field) ->
-          Error.toml_error filename path "Missing field: %s" field;
-          raise Exit
-      | Toml.Path_error (path, GenError msg) ->
-          Error.toml_error filename path "%s" msg;
-          raise Exit
-    in
+    let test = parse filename in
     run_testrepr ~short model test
 end

--- a/cli/tests/arm/seq/LDR+fn.litmus.toml
+++ b/cli/tests/arm/seq/LDR+fn.litmus.toml
@@ -1,0 +1,16 @@
+arch = "AArch64"
+name = "LDR+fn"
+symbolic = ["y"]
+
+[thread.0]
+init = { X1 = "bvor(b=0, a=y)" }
+code = """
+    LDR X0, [X1]
+"""
+
+[locations]
+y = "bvxor(bvor(a=0x28, b=0x2), 0)"
+
+[final]
+expect = "sat"
+assertion = "0:X0 = bvxor(bvor(a=0x28, b=0x2), 0) & 0:X1 = bvor(b=0, a=y)"

--- a/cli/tests/converter/expect/arm/seq/LDR+fn.litmus.toml
+++ b/cli/tests/converter/expect/arm/seq/LDR+fn.litmus.toml
@@ -1,0 +1,56 @@
+arch = "Arm"
+name = "LDR+fn"
+
+[[registers]]
+  _PC = 0x2000
+  "R1" = 0x1000
+  "R0" = 0
+  "R2" = 0
+  "R3" = 0
+  "R4" = 0
+  "R5" = 0
+  "R6" = 0
+  "R7" = 0
+  "R8" = 0
+  "R9" = 0
+  "R10" = 0
+  "R11" = 0
+  "R12" = 0
+  "R13" = 0
+  "R14" = 0
+  "R15" = 0
+  "R16" = 0
+  "R17" = 0
+  "R18" = 0
+  "R19" = 0
+  "R20" = 0
+  "R21" = 0
+  "R22" = 0
+  "R23" = 0
+  "R24" = 0
+  "R25" = 0
+  "R26" = 0
+  "R27" = 0
+  "R28" = 0
+  "R29" = 0
+  "R30" = 0
+  "SCTLR_EL1" = 0
+  PSTATE = {EL = 0, SP = 0}
+
+[[memory]]
+  kind = "code"
+  addr = 0x2000
+  step = 4
+  data = 0xf9400020
+
+[[memory]]
+  sym = "y"
+  addr = 0x1000
+  step = 8
+  data = 0x2a
+
+[[termCond]]
+  _PC = 0x2004
+
+[final]
+  assertion = {and = [{"0:R0" = 0x2a}, {"0:R1" = 0x1000}]}

--- a/cli/tests/errors/duplicate-isla-fn-arg.litmus.toml
+++ b/cli/tests/errors/duplicate-isla-fn-arg.litmus.toml
@@ -1,0 +1,15 @@
+arch = "AArch64"
+name = "duplicate-isla-fn-arg"
+symbolic = ["x"]
+
+[thread.0]
+code = """
+    NOP
+"""
+
+[locations]
+x = "bvor(a=0x1, a=0x2, b=0)"
+
+[final]
+expect = "sat"
+assertion = "true"

--- a/cli/tests/errors/errors.t
+++ b/cli/tests/errors/errors.t
@@ -61,7 +61,42 @@ Too much data for step
 
 Invalid reset value in Isla file
   $ archsem convert --format isla invalid-reset.litmus.toml
-  archsem: internal error, uncaught exception:
-           TOML error at "thread.reset.X0": register X0 has invalid reset value: Isla value is invalid, should be int or string, but is: true
-           
-  [125]
+  archsem: TOML error:
+  File "invalid-reset.litmus.toml", path "thread.reset.X0":
+  register X0 has invalid reset value: Isla value is invalid, should be int or string expression, but is: true
+  [1]
+
+Unknown Isla function
+  $ archsem seq unknown-isla-fn.litmus.toml
+  archsem: eval error:
+  File "unknown-isla-fn.litmus.toml", path "locations.x":
+  function: unknown unknown_fn/1
+  [1]
+
+Missing Isla function argument
+  $ archsem seq missing-isla-fn-arg.litmus.toml
+  archsem: eval error:
+  File "missing-isla-fn-arg.litmus.toml", path "locations.x":
+  function: bvor: missing argument b
+  [1]
+
+Duplicate Isla function argument
+  $ archsem seq duplicate-isla-fn-arg.litmus.toml
+  archsem: eval error:
+  File "duplicate-isla-fn-arg.litmus.toml", path "locations.x":
+  function: bvor: duplicate argument a
+  [1]
+
+Isla function error in register initialization
+  $ archsem seq init-isla-fn-error.litmus.toml
+  archsem: eval error:
+  File "init-isla-fn-error.litmus.toml", path "thread.0.init.R0":
+  function: unknown unknown_fn/1
+  [1]
+
+Isla function error in final assertion
+  $ archsem seq final-isla-fn-error.litmus.toml
+  archsem: eval error:
+  File "final-isla-fn-error.litmus.toml", path "final.assertion":
+  function: unknown unknown_fn/1
+  [1]

--- a/cli/tests/errors/final-isla-fn-error.litmus.toml
+++ b/cli/tests/errors/final-isla-fn-error.litmus.toml
@@ -1,0 +1,11 @@
+arch = "AArch64"
+name = "final-isla-fn-error"
+
+[thread.0]
+code = """
+    NOP
+"""
+
+[final]
+expect = "sat"
+assertion = "0:X0 = unknown_fn(0x1)"

--- a/cli/tests/errors/init-isla-fn-error.litmus.toml
+++ b/cli/tests/errors/init-isla-fn-error.litmus.toml
@@ -1,0 +1,12 @@
+arch = "AArch64"
+name = "init-isla-fn-error"
+
+[thread.0]
+init = { R0 = "unknown_fn(0x1)" }
+code = """
+    NOP
+"""
+
+[final]
+expect = "sat"
+assertion = "true"

--- a/cli/tests/errors/missing-isla-fn-arg.litmus.toml
+++ b/cli/tests/errors/missing-isla-fn-arg.litmus.toml
@@ -1,0 +1,15 @@
+arch = "AArch64"
+name = "missing-isla-fn-arg"
+symbolic = ["x"]
+
+[thread.0]
+code = """
+    NOP
+"""
+
+[locations]
+x = "bvor(a=0x1)"
+
+[final]
+expect = "sat"
+assertion = "true"

--- a/cli/tests/errors/unknown-isla-fn.litmus.toml
+++ b/cli/tests/errors/unknown-isla-fn.litmus.toml
@@ -1,0 +1,15 @@
+arch = "AArch64"
+name = "unknown-isla-fn"
+symbolic = ["x"]
+
+[thread.0]
+code = """
+    NOP
+"""
+
+[locations]
+x = "unknown_fn(0x1)"
+
+[final]
+expect = "sat"
+assertion = "true"

--- a/cli/tests/unit/isla/assertion_test.ml
+++ b/cli/tests/unit/isla/assertion_test.ml
@@ -54,6 +54,8 @@ let sym s = Sym s
 
 let cst v = Const v
 
+let kwfn name args = KwFn (name, args)
+
 let parse = Isla.Ir.parse_assertion_expr
 
 let parse_cases =
@@ -63,6 +65,12 @@ let parse_cases =
     ("symbol on rhs", "0:X0 = x", Atom (CmpCst (reg 0 "X0", sym "x")));
     ("register on rhs", "0:X0 = 2:X2", Atom (CmpLoc (reg 0 "X0", reg 2 "X2")));
     ("memory on rhs", "0:X0 = *x", Atom (CmpLoc (reg 0 "X0", mem "x")));
+    ( "function on rhs",
+      "0:X0 = bvor(a=0x28, b=0x2)",
+      Atom
+        (CmpCst (reg 0 "X0", kwfn "bvor" [("a", cst (n 0x28)); ("b", cst (n 0x2))])
+        )
+    );
     ("negation", "~(1:X0 = 1)", Not (Atom (CmpCst (reg 1 "X0", cst Z.one))));
     ( "conjunction",
       "1:X0 = 1 & 2:X0 = 0",


### PR DESCRIPTION
- Add Fn/KwFn term forms and parse TOML string values as term expressions.
- Add a function registry with built-in bitvector operations for static term evaluation.