### PR TITLE
fix(arm): Support split PSTATE from sail-tiny-arm

### DIFF
--- a/ArchSemArm/ArmInst.v
+++ b/ArchSemArm/ArmInst.v
@@ -60,29 +60,19 @@ Module ArchExtra <: FromSail.ArchExtra SA.
   Definition pc_reg : reg := _PC.
   Definition reg_of_string := register_of_string.
 
-  Equations set_ProcState_gen_field (field : string) (val : reg_gen_val)
-    (p : ProcState) : result string ProcState :=
-    set_ProcState_gen_field "EL" (RVNumber z) p :=
-      Ok $ setv ProcState_EL (Z_to_bv 2 z) p;
-    set_ProcState_gen_field "SP" (RVNumber z) p :=
-      Ok $ setv ProcState_SP (Z_to_bv 1 z) p;
-    set_ProcState_gen_field field _ _ :=
-      Error ("Error setting " ++ field ++ " in PSTATE")%string.
-
   Equations reg_type_of_gen (r : reg) (rv : reg_gen_val) :
     result string (reg_type r) :=
+    reg_type_of_gen (R_bitvector_1 _) (RVNumber z) := Ok (Z_to_bv 1 z);
+    reg_type_of_gen (R_bitvector_2 _) (RVNumber z) := Ok (Z_to_bv 2 z);
+    reg_type_of_gen (R_bitvector_4 _) (RVNumber z) := Ok (Z_to_bv 4 z);
     reg_type_of_gen (R_bitvector_64 _) (RVNumber z) := Ok (Z_to_bv 64 z);
-    reg_type_of_gen (R_ProcState _) (RVStruct l) :=
-      foldlM (λ ps '(field, val), set_ProcState_gen_field field val ps) inhabitant l;
     reg_type_of_gen r _ := Error ("Error decoding " ++ pretty r)%string.
 
   Equations reg_type_to_gen (r : reg) (rv : reg_type r) : reg_gen_val :=
-    reg_type_to_gen (R_bitvector_64 _) bv := RVNumber (bv_unsigned bv);
-    reg_type_to_gen (R_ProcState _) ps :=
-      RVStruct [
-          ("EL", RVNumber (bv_unsigned (ProcState_EL ps)));
-          ("SP", RVNumber (bv_unsigned (ProcState_SP ps)));
-          ("TODO", RVString "other fields")].
+    reg_type_to_gen (R_bitvector_1 _) bv := RVNumber (bv_unsigned bv);
+    reg_type_to_gen (R_bitvector_2 _) bv := RVNumber (bv_unsigned bv);
+    reg_type_to_gen (R_bitvector_4 _) bv := RVNumber (bv_unsigned bv);
+    reg_type_to_gen (R_bitvector_64 _) bv := RVNumber (bv_unsigned bv).
 End ArchExtra.
 
 (** Then we can use this to generate an ArchSem architecture module *)

--- a/ArchSemArm/tests/ArmSeqModelTest.v
+++ b/ArchSemArm/tests/ArmSeqModelTest.v
@@ -59,12 +59,6 @@ Definition r0_extract `(a : archModel.Res.t ∅ 1 term) : result string Z :=
   | archModel.Res.Flagged e => match e with end
   end.
 
-(** * Helper functions for PSTATE setup *)
-Definition init_pstate (el : bv 2) (sp : bv 1) : ProcState :=
-  inhabitant
-  |> set ProcState_EL (λ _, el)
-  |> set ProcState_SP (λ _, sp).
-
 (** We test against the sail-tiny-arm semantic, with non-determinism enabled *)
 Definition arm_sem := sail_tiny_arm_sem true.
 
@@ -79,7 +73,7 @@ Definition init_reg : registerMap :=
   |> reg_insert R1 0x11
   |> reg_insert R2 0x101
   |> reg_insert SCTLR_EL1 0x0
-  |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+  |> reg_insert CurrentEL 0x0.
 
 Definition init_mem : memoryMap:=
   ∅
@@ -109,7 +103,7 @@ Definition init_reg : registerMap :=
   |> reg_insert R0 0x1000
   |> reg_insert R1 0x0
   |> reg_insert SCTLR_EL1 0x0
-  |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+  |> reg_insert CurrentEL 0x0.
 
 Definition init_mem : memoryMap:=
   ∅
@@ -140,7 +134,7 @@ Module STRLDR. (* STR X2, [X1, X0]; LDR X0, [X1, X0] at 0x500, using address 0x1
     |> reg_insert R1 0x100
     |> reg_insert R2 0x2a
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap:=
     ∅

--- a/ArchSemArm/tests/UMPromisingTest.v
+++ b/ArchSemArm/tests/UMPromisingTest.v
@@ -75,12 +75,6 @@ Definition regs_extract {n} (regs : list (fin n * register_bitvector_64))
   | archModel.Res.Flagged e => match e with end
   end.
 
-(** * Helper functions for PSTATE setup *)
-Definition init_pstate (el : bv 2) (sp : bv 1) : ProcState :=
-  inhabitant
-  |> set ProcState_EL (λ _, el)
-  |> set ProcState_SP (λ _, sp).
-
 (** We test against the sail-tiny-arm semantic, with non-determinism enabled *)
 Definition arm_sem := sail_tiny_arm_sem true.
 
@@ -94,7 +88,7 @@ Module EOR.
     |> reg_insert R1 0x11
     |> reg_insert R2 0x101
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -136,7 +130,7 @@ Module LDR. (* LDR X0, [X1, X0] at 0x500, loading from 0x1000 *)
     |> reg_insert R0 0x1000
     |> reg_insert R1 0x0
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap:=
     ∅
@@ -180,7 +174,7 @@ Module STRLDR. (* STR X2, [X1, X0]; LDR X0, [X1, X0] at 0x500, using address 0x1
     |> reg_insert R1 0x100
     |> reg_insert R2 0x2a
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap:=
     ∅
@@ -236,7 +230,7 @@ Module MP.
     |> reg_insert R2 0x2a
     |> reg_insert R5 0x1
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_reg_t2 : registerMap :=
     ∅
@@ -248,7 +242,7 @@ Module MP.
     |> reg_insert R2 0x0
     |> reg_insert R5 0x0
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -317,7 +311,7 @@ Module MPDMBS.
     |> reg_insert R2 0x2a
     |> reg_insert R5 0x1
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_reg_t2 : registerMap :=
     ∅
@@ -329,7 +323,7 @@ Module MPDMBS.
     |> reg_insert R2 0x0
     |> reg_insert R5 0x0
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -399,7 +393,7 @@ Module LB.
     |> reg_insert R3 0x2000
     |> reg_insert R4 0x0
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_reg_t2 : registerMap :=
     ∅
@@ -410,7 +404,7 @@ Module LB.
     |> reg_insert R3 0x1000
     |> reg_insert R4 0x0
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -475,7 +469,7 @@ Module LBDMBS.
     |> reg_insert R3 0x2000
     |> reg_insert R4 0x0
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_reg_t2 : registerMap :=
     ∅
@@ -486,7 +480,7 @@ Module LBDMBS.
     |> reg_insert R3 0x1000
     |> reg_insert R4 0x0
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -550,7 +544,7 @@ Module STRW_LDRX. (* STR W2, [X1, X0]; LDR X0, [X1, X0] — 4-byte write, 8-byte
     |> reg_insert R1 0x100
     |> reg_insert R2 0x2a
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -597,7 +591,7 @@ Module CoWWRmixed.
     |> reg_insert R1 0x1100
     |> reg_insert R2 0x1111111111111111
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_reg_t1 : registerMap :=
     ∅
@@ -606,7 +600,7 @@ Module CoWWRmixed.
     |> reg_insert R1 0x1100
     |> reg_insert R3 0x22222222
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x0.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -641,4 +635,3 @@ Module CoWWRmixed.
     apply NoDup_Permutation; try solve_NoDup; set_solver.
   Qed.
 End CoWWRmixed.
-

--- a/ArchSemArm/tests/VMPromisingTest.v
+++ b/ArchSemArm/tests/VMPromisingTest.v
@@ -77,12 +77,6 @@ Definition regs_extract {n} (regs : list (fin n * register_bitvector_64))
   | archModel.Res.Flagged f => match f with end
   end.
 
-(** * Helper functions for PSTATE setup *)
-Definition init_pstate (el : bv 2) (sp : bv 1) : ProcState :=
-  inhabitant
-  |> set ProcState_EL (λ _, el)
-  |> set ProcState_SP (λ _, sp).
-
 (** * Helper functions for page table setup *)
 
 Definition table_desc (next_pa : Z) : Z :=
@@ -104,7 +98,7 @@ Module EORMMUOFF.
     |> reg_insert R1 0x11
     |> reg_insert R2 0x101
     |> reg_insert SCTLR_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -170,7 +164,7 @@ Module EOR.
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -228,7 +222,7 @@ Module LDR.
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_mem : memoryMap:=
     ∅
@@ -287,7 +281,7 @@ Module STRLDR.
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_mem : memoryMap:=
     ∅
@@ -354,7 +348,7 @@ Module LDRPT.
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 1%bv 1%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -442,7 +436,7 @@ Module MP.
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_reg_t2 : registerMap :=
     ∅
@@ -457,7 +451,7 @@ Module MP.
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -533,7 +527,7 @@ Module MPDMBS.
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_reg_t2 : registerMap :=
     ∅
@@ -548,7 +542,7 @@ Module MPDMBS.
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 0%bv 0%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_mem : memoryMap :=
     ∅
@@ -621,7 +615,7 @@ Module BBMSuccess.
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 1%bv 1%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_reg_t2 : registerMap :=
     ∅
@@ -634,7 +628,7 @@ Module BBMSuccess.
     |> reg_insert ESR_EL1 0x0
     |> reg_insert VBAR_EL1 0x0       (* Exception vector base - needed for fault handling *)
     |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert PSTATE (init_pstate 1%bv 1%bv).
+    |> reg_insert CurrentEL 0x1.
 
   Definition init_mem : memoryMap :=
     ∅

--- a/cli/tests/arm/seq-mixed/STRW_LDRX.archsem.toml
+++ b/cli/tests/arm/seq-mixed/STRW_LDRX.archsem.toml
@@ -9,7 +9,7 @@ R0 = 0x1000
 R1 = 0x100
 R2 = 0x2a
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/arm/seq/EOR+EL1.litmus.toml
+++ b/cli/tests/arm/seq/EOR+EL1.litmus.toml
@@ -1,0 +1,10 @@
+arch="Arm"
+name="EOR+EL1"
+
+[thread.0]
+init = {X1 = 0x11, X2 = 0x101, "PSTATE.EL" = 1}
+code = "EOR X0, X1, X2"
+
+[final]
+kind = "forall"
+assertion = "0:X0 = 0x110"

--- a/cli/tests/arm/seq/EOR.archsem.toml
+++ b/cli/tests/arm/seq/EOR.archsem.toml
@@ -7,7 +7,7 @@ R0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/arm/seq/NOP+mem.archsem.toml
+++ b/cli/tests/arm/seq/NOP+mem.archsem.toml
@@ -5,7 +5,7 @@ name="NOP+mem"
 _PC = 0x500
 R0 = 0x0
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/arm/um-mixed/CoWWR+mixed.archsem.toml
+++ b/cli/tests/arm/um-mixed/CoWWR+mixed.archsem.toml
@@ -13,7 +13,7 @@ _PC = 0x500
 R1 = 0x1100
 R2 = 0x1111111111111111
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500
@@ -32,7 +32,7 @@ R0 = 0x0
 R1 = 0x1100
 R3 = 0x22222222
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x600

--- a/cli/tests/arm/um/MP+dmbs.archsem.toml
+++ b/cli/tests/arm/um/MP+dmbs.archsem.toml
@@ -11,7 +11,7 @@ R3 = 0x1000
 R4 = 0x200
 R5 = 0x1
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500
@@ -35,7 +35,7 @@ R3 = 0x1000
 R4 = 0x200
 R5 = 0x0
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00 }
+CurrentEL = 0b00
 
 # Thread 1 Instructions
 [[memory]]

--- a/cli/tests/arm/um/MP.archsem.toml
+++ b/cli/tests/arm/um/MP.archsem.toml
@@ -11,7 +11,7 @@ R3 = 0x1000
 R4 = 0x200
 R5 = 0x1
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b00 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500
@@ -33,7 +33,7 @@ R3 = 0x1000
 R4 = 0x200
 R5 = 0x0
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b00 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x600

--- a/cli/tests/arm/vm-mixed/STRWPT+VM.archsem.toml
+++ b/cli/tests/arm/vm-mixed/STRWPT+VM.archsem.toml
@@ -17,7 +17,7 @@ TTBR0_EL1 = 0x80000
 TCR_EL1 = 0x0
 SCTLR_EL1 = 0x1
 ID_AA64MMFR1_EL1 = 0x0
-PSTATE = { "EL" = 0b01, "SP" = 0b1 }
+CurrentEL = 0x1
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/arm/vm/BBMSuccess.archsem.toml
+++ b/cli/tests/arm/vm/BBMSuccess.archsem.toml
@@ -16,7 +16,7 @@ TTBR0_EL1 = 0x80000
 TCR_EL1 = 0x0
 SCTLR_EL1 = 0x1
 ID_AA64MMFR1_EL1 = 0x0
-PSTATE = { "EL" = 0b01, "SP" = 0b1 }
+CurrentEL = 0b01
 
 # Instructions:
 [[memory]]

--- a/cli/tests/arm/vm/LDRPT+NoBBM.archsem.toml
+++ b/cli/tests/arm/vm/LDRPT+NoBBM.archsem.toml
@@ -17,7 +17,7 @@ TTBR0_EL1 = 0x80000
 TCR_EL1 = 0x0
 SCTLR_EL1 = 0x1
 ID_AA64MMFR1_EL1 = 0x0
-PSTATE = { "EL" = 0b01, "SP" = 0b1 }
+CurrentEL = 0b01
 
 # Instructions:
 # LDR X0, [X1, X0] - first load: 0xf8606820

--- a/cli/tests/arm/vm/MP+VM.archsem.toml
+++ b/cli/tests/arm/vm/MP+VM.archsem.toml
@@ -17,7 +17,7 @@ TTBR0_EL1 = 0x80000
 TCR_EL1 = 0x0
 SCTLR_EL1 = 0x1
 ID_AA64MMFR1_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b01
 
 # Thread 0 instructions at PA 0x500
 [[memory]]
@@ -45,7 +45,7 @@ TTBR0_EL1 = 0x80000
 TCR_EL1 = 0x0
 SCTLR_EL1 = 0x1
 ID_AA64MMFR1_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b01
 
 # Thread 1 instructions at PA 0x600
 [[memory]]

--- a/cli/tests/arm/vm/STRLDR+VM.archsem.toml
+++ b/cli/tests/arm/vm/STRLDR+VM.archsem.toml
@@ -14,7 +14,7 @@ TTBR0_EL1 = 0x80000    # Page table base (physical address)
 TCR_EL1 = 0x0          # Translation control register
 SCTLR_EL1 = 0x1        # MMU enabled
 ID_AA64MMFR1_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b01
 
 # Instructions at PA 0x500 (VA 0x8000000500)
 [[memory]]

--- a/cli/tests/converter/expect/arm/seq-mixed/STRW_LDRX.archsem.toml
+++ b/cli/tests/converter/expect/arm/seq-mixed/STRW_LDRX.archsem.toml
@@ -23,7 +23,7 @@ name = "STRW_LDRX"
   "R1" = 0x100
   "R2" = 0x2a
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0}
+  CurrentEL = 0
 
 [final]
   assertion = {"0:R0" = 0x2a}

--- a/cli/tests/converter/expect/arm/seq-mixed/STRW_LDRX.litmus.toml
+++ b/cli/tests/converter/expect/arm/seq-mixed/STRW_LDRX.litmus.toml
@@ -52,7 +52,10 @@ name = "STRW_LDRX"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [final]
   assertion = {"0:R0" = 0x2a}

--- a/cli/tests/converter/expect/arm/seq/EOR+EL1.litmus.toml
+++ b/cli/tests/converter/expect/arm/seq/EOR+EL1.litmus.toml
@@ -1,28 +1,23 @@
 arch = "Arm"
-name = "LDR+fn"
+name = "EOR+EL1"
 
 [[memory]]
   kind = "code"
-  addr = 0x2000
-  step = 4
-  data = 0xf9400020
-
-[[memory]]
-  sym = "y"
   addr = 0x1000
-  step = 8
-  data = 0x2a
+  step = 4
+  data = 0xca020020
 
 [thread]
 
 [thread."0"]
-  breakpoints = [0x2004]
+  breakpoints = [0x1004]
 
 [thread."0".regs]
-  _PC = 0x2000
-  "R1" = 0x1000
+  _PC = 0x1000
+  "R1" = 0x11
+  "R2" = 0x101
+  CurrentEL = 1
   "R0" = 0
-  "R2" = 0
   "R3" = 0
   "R4" = 0
   "R5" = 0
@@ -52,10 +47,10 @@ name = "LDR+fn"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  CurrentEL = 0
   SPSel = 0
   NZCV = 0
   DAIF = 0
 
 [final]
-  assertion = {and = [{"0:R0" = 0x2a}, {"0:R1" = 0x1000}]}
+  assertion = {"0:R0" = 0x110}
+  kind = "forall"

--- a/cli/tests/converter/expect/arm/seq/EOR+section.litmus.toml
+++ b/cli/tests/converter/expect/arm/seq/EOR+section.litmus.toml
@@ -53,7 +53,10 @@ name = "EOR+section"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [final]
   assertion = {"0:R0" = 0x110}

--- a/cli/tests/converter/expect/arm/seq/EOR.archsem.toml
+++ b/cli/tests/converter/expect/arm/seq/EOR.archsem.toml
@@ -18,7 +18,7 @@ name = "EOR"
   "R1" = 0x11
   "R2" = 0x101
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
 
 [final]
   assertion = {and = [{"0:_PC" = 0x504}, {"0:R0" = 0x110}]}

--- a/cli/tests/converter/expect/arm/seq/EOR.litmus.toml
+++ b/cli/tests/converter/expect/arm/seq/EOR.litmus.toml
@@ -46,7 +46,10 @@ name = "EOR"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [final]
   assertion = {"0:R0" = 0x110}

--- a/cli/tests/converter/expect/arm/seq/NOP+mem.archsem.toml
+++ b/cli/tests/converter/expect/arm/seq/NOP+mem.archsem.toml
@@ -22,7 +22,7 @@ name = "NOP+mem"
   _PC = 0x500
   "R0" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
 
 [final]
   assertion = {and = [{"0:R0" = 0}, {x = 0x2a}]}

--- a/cli/tests/converter/expect/arm/um-mixed/CoWWR+mixed.archsem.toml
+++ b/cli/tests/converter/expect/arm/um-mixed/CoWWR+mixed.archsem.toml
@@ -28,7 +28,7 @@ name = "CoWWR+mixed"
   "R1" = 0x1100
   "R2" = 0x1111111111111111
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0}
+  CurrentEL = 0
 
 [thread."1"]
   breakpoints = [0x608]
@@ -39,7 +39,7 @@ name = "CoWWR+mixed"
   "R1" = 0x1100
   "R3" = 0x22222222
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0}
+  CurrentEL = 0
 
 [final]
   assertion = {or = [{"1:R0" = 0x1111111122222222}, {"1:R0" = 0x1111111111111111}, {"1:R0" = 0x22222222}]}

--- a/cli/tests/converter/expect/arm/um-mixed/CoWWR+mixed.litmus.toml
+++ b/cli/tests/converter/expect/arm/um-mixed/CoWWR+mixed.litmus.toml
@@ -58,7 +58,10 @@ name = "CoWWR+mixed"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [thread."1"]
   breakpoints = [0x200c]
@@ -97,7 +100,10 @@ name = "CoWWR+mixed"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [final]
   assertion = {or = [{"1:R0" = 0x22222222}, {"1:R0" = 0x1111111111111111}, {"1:R0" = 0x1111111122222222}]}

--- a/cli/tests/converter/expect/arm/um/MP+dmbs.archsem.toml
+++ b/cli/tests/converter/expect/arm/um/MP+dmbs.archsem.toml
@@ -37,7 +37,7 @@ name = "MP+dmbs"
   "R4" = 0x200
   "R5" = 1
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0}
+  CurrentEL = 0
 
 [thread."1"]
   breakpoints = [0x60c]
@@ -51,7 +51,7 @@ name = "MP+dmbs"
   "R4" = 0x200
   "R5" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0}
+  CurrentEL = 0
 
 [final]
   assertion = {and = [{"1:R5" = 1}, {"1:R2" = 0}]}

--- a/cli/tests/converter/expect/arm/um/MP+dmbs.litmus.toml
+++ b/cli/tests/converter/expect/arm/um/MP+dmbs.litmus.toml
@@ -64,7 +64,10 @@ name = "MP+dmbs"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [thread."1"]
   breakpoints = [0x3018]
@@ -103,7 +106,10 @@ name = "MP+dmbs"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [final]
   assertion = {and = [{"1:R0" = 1}, {"1:R2" = 0}]}

--- a/cli/tests/converter/expect/arm/um/MP+section-call.litmus.toml
+++ b/cli/tests/converter/expect/arm/um/MP+section-call.litmus.toml
@@ -71,7 +71,10 @@ name = "MP+section-call"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [thread."1"]
   breakpoints = [0x4014]
@@ -110,7 +113,10 @@ name = "MP+section-call"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [final]
   assertion = {and = [{"1:R0" = 1}, {"1:R2" = 0}]}

--- a/cli/tests/converter/expect/arm/um/MP.archsem.toml
+++ b/cli/tests/converter/expect/arm/um/MP.archsem.toml
@@ -37,7 +37,7 @@ name = "MP"
   "R4" = 0x200
   "R5" = 1
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
 
 [thread."1"]
   breakpoints = [0x608]
@@ -51,7 +51,7 @@ name = "MP"
   "R4" = 0x200
   "R5" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
 
 [final]
   assertion = {and = [{"1:R5" = 1}, {"1:R2" = 0}]}

--- a/cli/tests/converter/expect/arm/um/MP.litmus.toml
+++ b/cli/tests/converter/expect/arm/um/MP.litmus.toml
@@ -64,7 +64,10 @@ name = "MP"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [thread."1"]
   breakpoints = [0x3010]
@@ -103,7 +106,10 @@ name = "MP"
   "R29" = 0
   "R30" = 0
   "SCTLR_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
 
 [final]
   assertion = {and = [{"1:R0" = 1}, {"1:R2" = 0}]}

--- a/cli/tests/converter/expect/arm/vm-mixed/STRWPT+VM.archsem.toml
+++ b/cli/tests/converter/expect/arm/vm-mixed/STRWPT+VM.archsem.toml
@@ -68,7 +68,7 @@ name = "STRWPT+VM"
   "TCR_EL1" = 0
   "SCTLR_EL1" = 1
   "ID_AA64MMFR1_EL1" = 0
-  PSTATE = {EL = 1, SP = 1}
+  CurrentEL = 1
 
 [final]
   assertion = {and = [{"0:R0" = 0x2a}, {or = [{"0:R4" = 0x2a}, {"0:R4" = 0x42}]}]}

--- a/cli/tests/converter/expect/arm/vm/BBMSuccess.archsem.toml
+++ b/cli/tests/converter/expect/arm/vm/BBMSuccess.archsem.toml
@@ -62,7 +62,7 @@ name = "BBMSuccess"
   "TCR_EL1" = 0
   "SCTLR_EL1" = 1
   "ID_AA64MMFR1_EL1" = 0
-  PSTATE = {EL = 1, SP = 1}
+  CurrentEL = 1
 
 [final]
   assertion = {"0:R3" = 0}

--- a/cli/tests/converter/expect/arm/vm/LDRPT+NoBBM.archsem.toml
+++ b/cli/tests/converter/expect/arm/vm/LDRPT+NoBBM.archsem.toml
@@ -68,7 +68,7 @@ name = "LDRPT+NoBBM"
   "TCR_EL1" = 0
   "SCTLR_EL1" = 1
   "ID_AA64MMFR1_EL1" = 0
-  PSTATE = {EL = 1, SP = 1}
+  CurrentEL = 1
 
 [final]
   assertion = {and = [{"0:R0" = 0x2a}, {or = [{"0:R4" = 0x2a}, {"0:R4" = 0x42}]}]}

--- a/cli/tests/converter/expect/arm/vm/MP+VM.archsem.toml
+++ b/cli/tests/converter/expect/arm/vm/MP+VM.archsem.toml
@@ -70,7 +70,7 @@ name = "MP+VM"
   "TCR_EL1" = 0
   "SCTLR_EL1" = 1
   "ID_AA64MMFR1_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 1
 
 [thread."1"]
   breakpoints = [0x8000000608]
@@ -87,7 +87,7 @@ name = "MP+VM"
   "TCR_EL1" = 0
   "SCTLR_EL1" = 1
   "ID_AA64MMFR1_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 1
 
 [final]
   assertion = {and = [{"1:R5" = 1}, {"1:R2" = 0}]}

--- a/cli/tests/converter/expect/arm/vm/STRLDR+VM.archsem.toml
+++ b/cli/tests/converter/expect/arm/vm/STRLDR+VM.archsem.toml
@@ -56,7 +56,7 @@ name = "STRLDR+VM"
   "TCR_EL1" = 0
   "SCTLR_EL1" = 1
   "ID_AA64MMFR1_EL1" = 0
-  PSTATE = {EL = 0, SP = 0}
+  CurrentEL = 1
 
 [final]
   assertion = {"0:R0" = 0x2a}

--- a/cli/tests/errors/invalid-register-final.archsem.toml
+++ b/cli/tests/errors/invalid-register-final.archsem.toml
@@ -7,7 +7,7 @@ R0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/errors/invalid-register.archsem.toml
+++ b/cli/tests/errors/invalid-register.archsem.toml
@@ -7,7 +7,7 @@ RRRRRRR0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/errors/invalid-step.archsem.toml
+++ b/cli/tests/errors/invalid-step.archsem.toml
@@ -7,7 +7,10 @@ R0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
+SPSel = 0b0
+NZCV = 0
+DAIF = 0
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/errors/invalid-symbol.archsem.toml
+++ b/cli/tests/errors/invalid-symbol.archsem.toml
@@ -7,7 +7,7 @@ R0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/errors/invalid-thread-final.archsem.toml
+++ b/cli/tests/errors/invalid-thread-final.archsem.toml
@@ -7,7 +7,7 @@ R0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/errors/missing-step.archsem.toml
+++ b/cli/tests/errors/missing-step.archsem.toml
@@ -7,7 +7,10 @@ R0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
+SPSel = 0b0
+NZCV = 0
+DAIF = 0
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/errors/name-mismatch.archsem.toml
+++ b/cli/tests/errors/name-mismatch.archsem.toml
@@ -7,7 +7,7 @@ R0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/errors/thread-numbers.archsem.toml
+++ b/cli/tests/errors/thread-numbers.archsem.toml
@@ -7,7 +7,7 @@ R0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
 
 [[memory]]
 addr = 0x500

--- a/cli/tests/errors/too-much-data.archsem.toml
+++ b/cli/tests/errors/too-much-data.archsem.toml
@@ -7,7 +7,10 @@ R0 = 0x0
 R1 = 0x11
 R2 = 0x101
 SCTLR_EL1 = 0x0
-PSTATE = { "EL" = 0b00, "SP" = 0b0 }
+CurrentEL = 0b00
+SPSel = 0b0
+NZCV = 0
+DAIF = 0
 
 [[memory]]
 addr = 0x500

--- a/config/Arm.toml
+++ b/config/Arm.toml
@@ -77,6 +77,8 @@ W27 = "R27"
 W28 = "R28"
 W29 = "R29"
 W30 = "R30"
+"PSTATE.EL" = "CurrentEL"
+"PSTATE.SP" = "SPSel"
 
 [registers.defaults]
 R0 = 0
@@ -111,4 +113,7 @@ R28 = 0
 R29 = 0
 R30 = 0
 SCTLR_EL1 = 0
-PSTATE = { EL = 0, SP = 0 }
+CurrentEL = 0
+SPSel = 0
+NZCV = 0
+DAIF = 0

--- a/coq-archsem-arm.opam.locked
+++ b/coq-archsem-arm.opam.locked
@@ -138,7 +138,7 @@ pin-depends: [
   ]
   [
     "coq-sail-tiny-arm.dev"
-    "git+https://github.com/rems-project/sail-tiny-arm.git#8ebfffe"
+    "git+https://github.com/rems-project/sail-tiny-arm.git#e1156083"
   ]
   [
     "coq-stdpp.1.12.0"


### PR DESCRIPTION
- Bump coq-sail-tiny-arm to sail-tiny-arm 319a6bd.
- Update Arm generic register conversion for split PSTATE bitvector registers.