### PR TITLE
fix(GenProm): Filter pending-promise errors

### DIFF
--- a/ArchSem/GenPromising.v
+++ b/ArchSem/GenPromising.v
@@ -457,8 +457,10 @@ Module GenPromising (Arch : Arch) (Inter : InterfaceT Arch)
                  else None) in
         let errors :=
           res |> Exec.errors |>
-            omap (λ '((new_proms, _), err_msg),
-                if is_emptyb new_proms then Some err_msg
+            omap (λ '((new_proms, st), err_msg),
+                if is_emptyb new_proms
+                   && prom.(tState_nopromises) (PPState.state st)
+                then Some err_msg
                 else None) in
         {|promises:=promises;
           final_states:=tstates;


### PR DESCRIPTION
## Summary
Reports promise-first enumeration errors only when no new promises were discovered. 

It avoids treating an error trace with unfulfilled pending promises as an observable model error. Such traces are failed certification witnesses, not completed executions. 

This fix is also related to the next PR about the BBM success test case. It prevents that test from emitting a spurious fault/error branch caused by a future promised PTE invalidation that is never certified.
