### PR TITLE
fix(arm): Repair translation semantics

### DIFF
--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -1341,6 +1341,19 @@ Module TLB.
     '(tlb, _) ← update init ts mem_init mem 0 va ttbr;
     unique_snapshots_va_between ts mem_init mem tlb 0 time va ttbr [(tlb, 0)].
 
+  (** Find snapshots at or after [time].
+
+      If [time] falls between two snapshots, keep the closest earlier TLB state
+      as a snapshot at [time]. *)
+  Fixpoint snapshots_from (time : nat) (snapshots : list (t * nat))
+      : list (t * nat) :=
+    match snapshots with
+    | [] => []
+    | (tlb, t) :: snapshots =>
+      if time <? t then (tlb, t) :: snapshots_from time snapshots
+      else [(tlb, time)]
+    end.
+
   (** ** TLB Snapshot Functions for All VAs (BBM Checking) *)
 
   (** Compute unique TLB snapshots over a time range for BBM checking.
@@ -2087,8 +2100,8 @@ Definition run_barrier (barrier : barrier) (vmax_t : view) :
   | _ => mthrow "Unsupported barrier"
   end.
 
-Definition run_tlbi (tid : nat) (view : nat) (tlbi : TLBIInfo) :
-    Exec.t (PPState.t TState.t Ev.t IIS.t) string () :=
+Definition run_tlbi (tid : nat) (viio : view) (tlbi : TLBIInfo) :
+    Exec.t (PPState.t TState.t Ev.t IIS.t) string (option view) :=
   guard_or
     "Non-shareable TLBIs are not supported"
     (tlbi.(TLBIInfo_shareability) ≠ Shareability_NSH);;
@@ -2103,7 +2116,7 @@ Definition run_tlbi (tid : nat) (view : nat) (tlbi : TLBIInfo) :
   ts ← mget PPState.state;
   iis ← mget PPState.iis;
   let vpre := ts.(TState.vcse) ⊔ ts.(TState.vdsb) ⊔ ((*iio*) IIS.strict iis)
-              ⊔ view ⊔ ts.(TState.vspec) in
+              ⊔ viio ⊔ ts.(TState.vspec) in
   '(tlbiev : TLBI.t) ←
     match tlbi.(TLBIInfo_rec).(TLBIRecord_op) with
     | TLBIOp_ALL => mret $ TLBI.All tid
@@ -2113,13 +2126,18 @@ Definition run_tlbi (tid : nat) (view : nat) (tlbi : TLBIInfo) :
     | _ => mthrow "Unsupported kind of TLBI"
     end;
   mem ← mget PPState.mem;
-  time ← (if Memory.fulfill tlbiev (TState.prom_tlbi ts) mem is Some t
-          then mret t
-          else Exec.liftSt PPState.mem $ Memory.promise tlbiev);
+  '(time, new_promise) ←
+    match Memory.fulfill tlbiev (TState.prom_tlbi ts) mem with
+    | Some t => mret (t, false)
+    | None =>
+      t ← Exec.liftSt PPState.mem $ Memory.promise tlbiev;
+      mret (t, true)
+    end;
   guard_discard (vpre < time)%nat;;
   mset (TState.prom_tlbi ∘ PPState.state) (filter (λ t, t ≠ time));;
   mset PPState.state $ TState.update TState.vtlbi time;;
-  mset PPState.iis $ IIS.add time.
+  mset PPState.iis $ IIS.add time;;
+  mret (if (new_promise : bool) then Some vpre else None).
 
 Definition va_in_range (va : bv 64) : Prop :=
   let top_bits := bv_extract 48 16 va in
@@ -2190,6 +2208,7 @@ Definition run_trans_start (trans_start : TranslationStartInfo)
     if decide (va_in_range va) then
       ttbr ← mlift $ ttbr_of_regime va trans_start.(TranslationStartInfo_regime);
       snapshots ← mlift $ TLB.unique_snapshots_va_until ts init mem vmax_t va ttbr;
+      let snapshots := TLB.snapshots_from vpre_t snapshots in
       valid_entries ← mlift $
         TLB.get_valid_entries_from_snapshots snapshots mem tid va asid;
       invalid_entries ← mlift $
@@ -2254,6 +2273,7 @@ Definition run_trans_end (trans_end : trans_end) :
     let trans_time := trs.(IIS.TransRes.time) in
     let fault := trans_end.(AddressDescriptor_fault) in
     if decide (fault.(FaultRecord_statuscode) = Fault_None) then
+      mset snd $ IIS.add trans_time;;
       msetv (IIS.trs ∘ snd) None
     else
       is_ets3 ← mlift (ets3 ts);
@@ -2347,8 +2367,8 @@ Section RunOutcome.
       mret ((), None)
   | TlbOp tlbi =>
       viio ← mget (IIS.strict ∘ PPState.iis);
-      run_tlbi tid viio tlbi;;
-      mret ((), None)
+      vpre_opt ← run_tlbi tid viio tlbi;
+      mret ((), vpre_opt)
   | ReturnException =>
       mem ← mget PPState.mem;
       Exec.liftSt (PPState.state ×× PPState.iis) $ run_cse (length mem);;

--- a/ArchSemArm/tests/VMPromisingTest.v
+++ b/ArchSemArm/tests/VMPromisingTest.v
@@ -597,51 +597,55 @@ End MPDMBS.
 
 (* Break-before-make success case *)
 Module BBMSuccess.
-  (* Thread 0 updates the last-level PTE for VA 0x8000001000 and then
-     executes a simplified break-before-make sequence that only
-     invalidates the last-level mapping for that VA:
-       DSB ishst; TLBI VALE1IS, X0; DSB ish.
-    Thread 1 performs a data access via VA 0x8000001000.
+  (* Single thread that updates the last-level PTE for VA 0x8000001000
+     using the full break-before-make sequence:
+       load old; DSB ish; break; DSB ishst; TLBI VAE1IS, X7; DSB ish;
+       ISB; make; DSB ishst; ISB; load new.
   *)
 
-  Definition init_reg_t1 : registerMap :=
+  Definition init_reg : registerMap :=
     ∅
     |> reg_insert _PC 0x8000000500
-    |> reg_insert R0 0x8000001000    (* VA to load from *)
+    |> reg_insert R0 0x8000001000     (* VA to load from *)
     |> reg_insert R1 0x0
-    |> reg_insert R2 0x8000010008    (* VA of L3[1] descriptor *)
-    |> reg_insert R3 0x0
-    |> reg_insert SCTLR_EL1 0x1
-    |> reg_insert TCR_EL1 0x0
-    |> reg_insert TTBR0_EL1 0x80000
-    |> reg_insert ID_AA64MMFR1_EL1 0x0
-    |> reg_insert CurrentEL 0x1.
-
-  Definition init_reg_t2 : registerMap :=
-    ∅
-    |> reg_insert _PC 0x8000000600
-    |> reg_insert R0 0x8000001000    (* VA to load from *)
-    |> reg_insert R1 0x0
+    |> reg_insert R2 0x8000010008     (* VA of L3[1] descriptor *)
+    |> reg_insert R3 0x0              (* Invalid descriptor for the break *)
+    |> reg_insert R4 0x60000000002f83 (* New nG descriptor: VA -> PA 0x2000 *)
+    |> reg_insert R5 0x0              (* Value read from the old mapping *)
+    |> reg_insert R6 0x0              (* Value read from the new mapping *)
+    |> reg_insert R7 0x8000001        (* TLBI VA operand: page 0x8000001000 *)
+    |> reg_insert R8 0x0              (* Base offset for page table writes *)
     |> reg_insert SCTLR_EL1 0x1
     |> reg_insert TCR_EL1 0x0
     |> reg_insert TTBR0_EL1 0x80000
     |> reg_insert ESR_EL1 0x0
-    |> reg_insert VBAR_EL1 0x0       (* Exception vector base - needed for fault handling *)
-    |> reg_insert ID_AA64MMFR1_EL1 0x0
+    |> reg_insert FAR_EL1 0x0
+    |> reg_insert ELR_EL1 0x0
+    |> reg_insert VBAR_EL1 0x0
+    |> reg_insert ID_AA64MMFR1_EL1 0x2000000000
     |> reg_insert CurrentEL 0x1.
 
   Definition init_mem : memoryMap :=
     ∅
-    (* Instructions of T1 *)
-    |> mem_insert 0x500 4 0xf8226823  (* STR X3, [X1, X2] - invalidate the PTE *)
-    |> mem_insert 0x504 4 0xd5033a9f  (* DSB ISHST *)
-    |> mem_insert 0x508 4 0xd5088320  (* TLBI VAE1IS - TLB invalidate by 0x8000001000 *)
-    |> mem_insert 0x50C 4 0xd5033b9f  (* DSB ISH *)
-    |> mem_insert 0x510 4 0xd5033fdf  (* ISB *)
-    (* Instructions of T2 *)
-    |> mem_insert 0x600 4 0xf8606820  (* LDR X0, [X1, X0] - read 0x8000001000 *)
+    (* LDR X5, [X1, X0] - read through the old mapping *)
+    |> mem_insert 0x500 4 0xf8606825
+    |> mem_insert 0x504 4 0xd5033b9f  (* DSB ISH *)
+    (* STR X3, [X8, X2] - invalidate the PTE *)
+    |> mem_insert 0x508 4 0xf8226903
+    |> mem_insert 0x50C 4 0xd5033a9f  (* DSB ISHST *)
+    (* TLBI VAE1IS, X7 - TLB invalidate by 0x8000001000 *)
+    |> mem_insert 0x510 4 0xd5088327
+    |> mem_insert 0x514 4 0xd5033b9f  (* DSB ISH *)
+    |> mem_insert 0x518 4 0xd5033fdf  (* ISB *)
+    (* STR X4, [X8, X2] - install the new PTE *)
+    |> mem_insert 0x51C 4 0xf8226904
+    |> mem_insert 0x520 4 0xd5033a9f  (* DSB ISHST *)
+    |> mem_insert 0x524 4 0xd5033fdf  (* ISB *)
+    (* LDR X6, [X1, X0] - read through the new mapping *)
+    |> mem_insert 0x528 4 0xf8606826
     (* Data at two different physical locations *)
     |> mem_insert 0x1000 8 0x2a       (* Original PA - value 0x2a *)
+    |> mem_insert 0x2000 8 0x42       (* New PA - value 0x42 *)
     (* Page tables *)
     (* L0[1] -> L1 *)
     |> mem_insert 0x80008 8 0x81003
@@ -655,40 +659,27 @@ Module BBMSuccess.
        - L3[16] -> PA 0x83000 (VA alias to edit L3 via VA 0x8000010000)
     *)
     |> mem_insert 0x83000 8 0x40000000000783
-    |> mem_insert 0x83008 8 0x60000000001783
+    |> mem_insert 0x83008 8 0x60000000001f83
     |> mem_insert 0x83080 8 0x60000000083703.
 
-  Definition n_threads := 2%nat.
-
-  Definition terminate_at_t1 rm : bool :=
-    reg_lookup _PC rm =? Some (0x8000000514 : bv 64).
-
-  Definition terminate_at_t2 rm : bool :=
-    (* a valid translation *)
-    (reg_lookup _PC rm =? Some (0x8000000604 : bv 64))
-    (* or a fault *)
-    || ((reg_lookup FAR_EL1 rm =? Some (0x8000001000 : bv 64))
-        && (reg_lookup ELR_EL1 rm =? Some (0x8000000600 : bv 64))
-        && (reg_lookup ESR_EL1 rm =? Some (0x96000007 : bv 64))).
-
-  Definition terminate_at := [# terminate_at_t1; terminate_at_t2].
+  Definition n_threads := 1%nat.
 
   Definition termCond : terminationCondition n_threads :=
-    (λ tid rm, (terminate_at !!! tid) rm).
+    (λ tid rm, reg_lookup _PC rm =? Some (0x800000052C : bv 64)).
 
   Definition initState :=
     {|archState.memory := init_mem;
-      archState.regs := [# init_reg_t1; init_reg_t2];
+      archState.regs := [# init_reg];
       archState.address_space := PAS_NonSecure |}.
 
-  Definition fuel := 8%nat.
+  Definition fuel := 26%nat.
 
   Definition test_results_pf :=
-    VMPromising_pf BBM.Off arm_sem fuel n_threads termCond initState.
+    VMPromising_pf BBM.Lax arm_sem fuel n_threads termCond initState.
 
-  (* BBM check success *)
-  Goal elements (regs_extract [(1%fin, R0)] <$> test_results_pf) ≡ₚ
-      [Ok [0x2a%Z]].
+  (* The completed BBM sequence switches from the old to the new mapping. *)
+  Goal elements (regs_extract [(0%fin, R5); (0%fin, R6)] <$> test_results_pf) ≡ₚ
+      [Ok [0x2a%Z; 0x42%Z]].
   Proof.
     vm_compute (elements _).
     apply NoDup_Permutation; try solve_NoDup; set_solver.

--- a/cli/tests/arm/vm/BBMSuccess.archsem.toml
+++ b/cli/tests/arm/vm/BBMSuccess.archsem.toml
@@ -1,21 +1,30 @@
-# TLBI test, just a plain BBM invalidation sequence
-# Tests TLB invalidation behavior with page table modification
+# TLBI test, full break-before-make sequence
+# Tests TLB invalidation behavior with page table break and make
 # Based on the BBMSuccess test from VMPromisingTest.v
 
 arch="Arm"
 name="BBMSuccess"
 
-# Thread 1: Invalidates PTE and performs TLBI
+# Thread 0: load old; DSB; break; DSB; TLBI; DSB; ISB; make; DSB; ISB; load new
 [thread.0.regs]
 _PC = 0x8000000500
-R0 = 0x8000001000      # VA for TLBI target
+R0 = 0x8000001000      # VA to load from
 R1 = 0x0               # Base offset
 R2 = 0x8000010008      # VA of L3[1] descriptor (page table VA alias)
 R3 = 0x0               # Invalid entry (break)
+R4 = 0x60000000002f83  # New nG descriptor: VA -> PA 0x2000
+R5 = 0x0               # Value read from the old mapping
+R6 = 0x0               # Value read from the new mapping
+R7 = 0x8000001         # TLBI VA operand: page 0x8000001000
+R8 = 0x0               # Base offset for page table writes
 TTBR0_EL1 = 0x80000
 TCR_EL1 = 0x0
 SCTLR_EL1 = 0x1
-ID_AA64MMFR1_EL1 = 0x0
+ESR_EL1 = 0x0
+FAR_EL1 = 0x0
+ELR_EL1 = 0x0
+VBAR_EL1 = 0x0
+ID_AA64MMFR1_EL1 = 0x2000000000
 CurrentEL = 0b01
 
 # Instructions:
@@ -24,22 +33,32 @@ addr = 0x500
 kind = "code"
 step = 4
 data = [
-  0xf8226823, # STR X3, [X1, X2] - invalidate PTE
+  0xf8606825, # LDR X5, [X1, X0] - read old mapping
+  0xd5033b9f, # DSB ISH - order load before PTE update
+  0xf8226903, # STR X3, [X8, X2] - invalidate PTE
   0xd5033a9f, # DSB ISHST - store barrier
-  0xd5088320, # TLBI VAE1IS, X0 - TLB invalidate
+  0xd5088327, # TLBI VAE1IS, X7 - TLB invalidate
   0xd5033b9f, # DSB ISH - full barrier
-  0xd5033fdf] # ISB - instruction sync
+  0xd5033fdf, # ISB - instruction sync
+  0xf8226904, # STR X4, [X8, X2] - install new PTE
+  0xd5033a9f, # DSB ISHST - store barrier
+  0xd5033fdf, # ISB - instruction sync
+  0xf8606826] # LDR X6, [X1, X0] - read new mapping
 
 [thread.0]
-breakpoints = [0x8000000514]
-
-# TODO add a load in other thread and check it can only see old value or fault.
+breakpoints = [0x800000052C]
 
 # Data at PA 0x1000
 [[memory]]
 addr = 0x1000
 step = 8
 data = 0x2a
+
+# Data at PA 0x2000
+[[memory]]
+addr = 0x2000
+step = 8
+data = 0x42
 
 # L0 table base
 [[memory]]
@@ -52,7 +71,7 @@ data = 0
 [[memory]]
 addr = 0x80008
 step = 8
-data = 0x81803
+data = 0x81003
 
 # L1[0] -> L2
 [[memory]]
@@ -72,11 +91,11 @@ addr = 0x83000
 step = 8
 data = 0x40000000000783
 
-# L3[1]: data page (readable/writable)
+# L3[1]: nG data page (readable/writable)
 [[memory]]
 addr = 0x83008
 step = 8
-data = 0x60000000001783
+data = 0x60000000001f83
 
 # L3[16]: VA alias for page table at VA 0x8000010000 -> PA 0x83000
 [[memory]]
@@ -84,7 +103,6 @@ addr = 0x83080
 step = 8
 data = 0x60000000083703
 
-
 [final]
 kind = "forall"
-assertion."0:R3" = 0
+assertion.and = [{"0:R5" = 0x2a}, {"0:R6" = 0x42}]

--- a/cli/tests/converter/expect/arm/vm/BBMSuccess.archsem.toml
+++ b/cli/tests/converter/expect/arm/vm/BBMSuccess.archsem.toml
@@ -5,12 +5,17 @@ name = "BBMSuccess"
   kind = "code"
   addr = 0x500
   step = 4
-  data = [0xf8226823, 0xd5033a9f, 0xd5088320, 0xd5033b9f, 0xd5033fdf]
+  data = [0xf8606825, 0xd5033b9f, 0xf8226903, 0xd5033a9f, 0xd5088327, 0xd5033b9f, 0xd5033fdf, 0xf8226904, 0xd5033a9f, 0xd5033fdf, 0xf8606826]
 
 [[memory]]
   addr = 0x1000
   step = 8
   data = 0x2a
+
+[[memory]]
+  addr = 0x2000
+  step = 8
+  data = 0x42
 
 [[memory]]
   addr = 0x80000
@@ -20,7 +25,7 @@ name = "BBMSuccess"
 [[memory]]
   addr = 0x80008
   step = 8
-  data = 0x81803
+  data = 0x81003
 
 [[memory]]
   addr = 0x81000
@@ -40,7 +45,7 @@ name = "BBMSuccess"
 [[memory]]
   addr = 0x83008
   step = 8
-  data = 0x60000000001783
+  data = 0x60000000001f83
 
 [[memory]]
   addr = 0x83080
@@ -50,7 +55,7 @@ name = "BBMSuccess"
 [thread]
 
 [thread."0"]
-  breakpoints = [0x8000000514]
+  breakpoints = [0x800000052c]
 
 [thread."0".regs]
   _PC = 0x8000000500
@@ -58,12 +63,21 @@ name = "BBMSuccess"
   "R1" = 0
   "R2" = 0x8000010008
   "R3" = 0
+  "R4" = 0x60000000002f83
+  "R5" = 0
+  "R6" = 0
+  "R7" = 0x8000001
+  "R8" = 0
   "TTBR0_EL1" = 0x80000
   "TCR_EL1" = 0
   "SCTLR_EL1" = 1
-  "ID_AA64MMFR1_EL1" = 0
+  "ESR_EL1" = 0
+  "FAR_EL1" = 0
+  "ELR_EL1" = 0
+  "VBAR_EL1" = 0
+  "ID_AA64MMFR1_EL1" = 0x2000000000
   CurrentEL = 1
 
 [final]
-  assertion = {"0:R3" = 0}
+  assertion = {and = [{"0:R5" = 0x2a}, {"0:R6" = 0x42}]}
   kind = "forall"


### PR DESCRIPTION
- Start VM translation snapshot lookup from the translation pre-view while preserving the boundary TLB state.
- Return TLBI pre-view information so promised TLBI events are certified like writes.
- Convert BBMSuccess to a single-thread full BBM sequence and sync TOML expectations.