### PR TITLE
CLI: Parse negative Isla term literals

### DIFF
--- a/cli/lib/isla/bv_fns.ml
+++ b/cli/lib/isla/bv_fns.ml
@@ -40,10 +40,13 @@
 
 (** Bitvector functions: bvand, bvor, bvxor, bvshl, bvlshr, extz, exts. *)
 
-let int_of_bit_arg name arg value =
+let check_non_negative_arg name arg value =
   if Z.sign value < 0 then
     Litmus.Error.failwith "function: %s: argument %s must be non-negative" name
-      arg;
+      arg
+
+let int_of_bit_arg name arg value =
+  check_non_negative_arg name arg value;
   match Z.to_int value with
   | n -> n
   | exception Z.Overflow ->
@@ -99,7 +102,9 @@ let functions : (string * Fn_registry.fn_spec) list =
         eval =
           (fun args ->
             match args with
-            | [a; b] -> Z.shift_right a (int_of_bit_arg "bvlshr" "b" b)
+            | [a; b] ->
+                check_non_negative_arg "bvlshr" "a" a;
+                Z.shift_right a (int_of_bit_arg "bvlshr" "b" b)
             | _ -> Fn_registry.arity_error "bvlshr" 2 (List.length args)
           )
       }
@@ -110,6 +115,7 @@ let functions : (string * Fn_registry.fn_spec) list =
           (fun args ->
             match args with
             | [bits; len] ->
+                check_non_negative_arg "extz" "bits" bits;
                 ignore (int_of_bit_arg "extz" "len" len);
                 bits
             | _ -> Fn_registry.arity_error "extz" 2 (List.length args)

--- a/cli/lib/isla/converter.ml
+++ b/cli/lib/isla/converter.ml
@@ -92,16 +92,38 @@ let term_eval_context_path = function
   | Register_init (tid, reg) -> ["thread"; string_of_int tid; "init"; reg]
   | Final_assertion -> ["final"; "assertion"]
 
+let eval_error context fmt =
+  Printf.ksprintf
+    (fun msg -> raise (Term_eval_error (term_eval_context_path context, msg)))
+    fmt
+
 let eval_term ~context ~resolve_sym term =
-  try Term.eval ~resolve_sym term
-  with Failure msg ->
-    raise (Term_eval_error (term_eval_context_path context, msg))
+  try
+    let value = Term.eval ~resolve_sym term in
+    match context with
+    (* Final constants stay raw Z.t; registers read via bv_unsigned. *)
+    | Final_assertion when Z.sign value < 0 ->
+        eval_error context "final assertion values must be non-negative: %s"
+          (Z.format "%#x" value)
+    (* Memory values are converted with Z.to_bits. *)
+    | Location_init _ when Z.sign value < 0 ->
+        eval_error context "negative memory data is not allowed: %s"
+          (Z.format "%#x" value)
+    | _ -> value
+  with Failure msg -> eval_error context "%s" msg
+
+let normalize_register_gen ~arch ~context reg_name gen =
+  try
+    match arch with
+    | Litmus.Arch_id.Arm ->
+        Archsem.Arm.RegVal.(to_gen (of_string_gen reg_name gen))
+    | Litmus.Arch_id.X86 ->
+        Archsem.X86.RegVal.(to_gen (of_string_gen reg_name gen))
+  with Failure msg -> eval_error context "%s" msg
 
 let data_symbol_of_value ~context ~resolve_sym mem_size sym value =
-  { Assembler.name = sym;
-    init_bytes =
-      init_bytes_of_value mem_size sym (eval_term ~context ~resolve_sym value)
-  }
+  let value = eval_term ~context ~resolve_sym value in
+  {Assembler.name = sym; init_bytes = init_bytes_of_value mem_size sym value}
 
 let to_assembly_input (ir : Ir.t) : Assembler.assembly_input =
   let mem_size = default_memory_size () in
@@ -204,13 +226,14 @@ let find_section name (asm_result : Assembler.assembly_result) =
     asm_result.sections
 
 (** Build per-thread initial register maps: PC + user init + config defaults. *)
-let build_registers ~resolve_sym ~pc (start_pc : int) (thread : Ir.thread) =
+let build_registers ~arch ~resolve_sym ~pc (start_pc : int) (thread : Ir.thread) =
   let pc_entry = (pc, RegValGen.Number (Z.of_int start_pc)) in
   let used_regs =
     List.map
       (fun (reg, value) ->
          let context = Register_init (thread.tid, reg) in
-         (reg, RegValGen.Number (eval_term ~context ~resolve_sym value))
+         let gen = RegValGen.Number (eval_term ~context ~resolve_sym value) in
+         (reg, normalize_register_gen ~arch ~context reg gen)
        )
       thread.init
   in
@@ -232,7 +255,7 @@ let build_threads ~arch ~resolve_sym asm_result (threads : Ir.thread list) :
        assert (tid == thread.tid);
        (* Should have been checked before *)
        let sec = find_section (Printf.sprintf "thread%d" tid) asm_result in
-       let regs = build_registers ~resolve_sym ~pc sec.addr thread in
+       let regs = build_registers ~arch ~resolve_sym ~pc sec.addr thread in
        let breakpoints = [Z.of_int (sec.addr + Bytes.length sec.data)] in
        {Testrepr.regs; breakpoints}
      )

--- a/cli/lib/isla/ir.ml
+++ b/cli/lib/isla/ir.ml
@@ -76,10 +76,11 @@ let parse_term : Toml.t -> Term.t = function
   | TomlInteger i -> Term.Const i
   | TomlString s -> (
       let lexbuf = Lexing.from_string s in
-      try Parser.binding Lexer.token lexbuf
-      with Parser.Error ->
-        Toml.error "term parse error at position %d in: %s"
-          lexbuf.lex_curr_p.pos_cnum s
+      try Parser.binding Lexer.token lexbuf with
+      | Parser.Error ->
+          Toml.error "term parse error at position %d in: %s"
+            lexbuf.lex_curr_p.pos_cnum s
+      | Lexer.Error msg -> Toml.error "%s" msg
     )
   | value ->
       Toml.error
@@ -134,10 +135,11 @@ let parse_sections toml = Toml.get_table_key_values parse_section toml
 
 let parse_assertion_expr s =
   let lexbuf = Lexing.from_string s in
-  try Parser.assertion Lexer.token lexbuf
-  with Parser.Error ->
-    Toml.error "assertion parse error at position %d in: %s"
-      lexbuf.lex_curr_p.pos_cnum s
+  try Parser.assertion Lexer.token lexbuf with
+  | Parser.Error ->
+      Toml.error "assertion parse error at position %d in: %s"
+        lexbuf.lex_curr_p.pos_cnum s
+  | Lexer.Error msg -> Toml.error "%s" msg
 
 let parse_assertion toml =
   let assertion_str = Toml.get_string toml |> String.trim in

--- a/cli/lib/isla/lexer.mll
+++ b/cli/lib/isla/lexer.mll
@@ -40,12 +40,14 @@
 
 {
   open Parser
+
+  exception Error of string
 }
 
 let digit = ['0'-'9']
 let hex = ['0'-'9' 'a'-'f' 'A'-'F']
-let alpha = ['a'-'z' 'A'-'Z' '_']
-let alnum = alpha | digit
+let ident_start = ['a'-'z' 'A'-'Z' '_']
+let ident_char = ident_start | digit
 
 rule token = parse
   | [' ' '\t' '\n']+ { token lexbuf }
@@ -58,15 +60,16 @@ rule token = parse
   | '*' { STAR }
   | ':' { COLON }
   | ',' { COMMA }
+  | '-' { MINUS }
   | "true" { TRUE }
   | "false" { FALSE }
   | '0' ['x' 'X'] hex+ as s { NUM (Z.of_string s) }
   | '0' ['b' 'B'] ['0' '1']+ as s { NUM (Z.of_string s) }
   | digit+ as s { NUM (Z.of_string s) }
-  | alpha alnum* as s { IDENT s }
+  | ident_start ident_char* as s { IDENT s }
   | eof { EOF }
   | _ as c {
-      failwith (Printf.sprintf
+      raise (Error (Printf.sprintf
         "assertion lexer: unexpected character '%c' at position %d"
-        c (Lexing.lexeme_start lexbuf))
+        c (Lexing.lexeme_start lexbuf)))
     }

--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -53,6 +53,7 @@
 %token EQ "="
 %token STAR "*"
 %token COLON ":"
+%token MINUS "-"
 %token TRUE
 %token FALSE EOF
 
@@ -90,6 +91,7 @@ loc:
 
 term:
   | v = NUM { Term.Const v }
+  | "-"; v = NUM { Term.Const (Z.neg v) }
   | f = IDENT; "("; args = separated_list(",", term); ")" { Term.Fn (f, args) }
   | f = IDENT; "("; kw = separated_nonempty_list(",", kw_arg); ")" { Term.KwFn (f, kw) }
   | s = IDENT { Term.Sym s }

--- a/cli/tests/arm/seq/AND+negative-bitwise.litmus.toml
+++ b/cli/tests/arm/seq/AND+negative-bitwise.litmus.toml
@@ -1,0 +1,12 @@
+arch = "AArch64"
+name = "AND+negative-bitwise"
+
+[thread.0]
+init = { X1 = "bvand(-1, 0xff)", X2 = "bvxor(-1, 0xff)", X3 = "bvor(-2, 1)", X4 = "bvshl(-1, 1)" }
+code = """
+    AND X0, X1, X2
+    AND X5, X3, X4
+"""
+
+[final]
+assertion = "0:X0 = 0 & 0:X5 = 0xfffffffffffffffe"

--- a/cli/tests/converter/expect/arm/seq/AND+negative-bitwise.litmus.toml
+++ b/cli/tests/converter/expect/arm/seq/AND+negative-bitwise.litmus.toml
@@ -1,0 +1,55 @@
+arch = "Arm"
+name = "AND+negative-bitwise"
+
+[[memory]]
+  kind = "code"
+  addr = 0x1000
+  step = 4
+  data = [0x8a020020, 0x8a040065]
+
+[thread]
+
+[thread."0"]
+  breakpoints = [0x1008]
+
+[thread."0".regs]
+  _PC = 0x1000
+  "R1" = 0xff
+  "R2" = 0xffffffffffffff00
+  "R3" = 0xffffffffffffffff
+  "R4" = 0xfffffffffffffffe
+  "R0" = 0
+  "R5" = 0
+  "R6" = 0
+  "R7" = 0
+  "R8" = 0
+  "R9" = 0
+  "R10" = 0
+  "R11" = 0
+  "R12" = 0
+  "R13" = 0
+  "R14" = 0
+  "R15" = 0
+  "R16" = 0
+  "R17" = 0
+  "R18" = 0
+  "R19" = 0
+  "R20" = 0
+  "R21" = 0
+  "R22" = 0
+  "R23" = 0
+  "R24" = 0
+  "R25" = 0
+  "R26" = 0
+  "R27" = 0
+  "R28" = 0
+  "R29" = 0
+  "R30" = 0
+  "SCTLR_EL1" = 0
+  CurrentEL = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
+
+[final]
+  assertion = {and = [{"0:X0" = 0}, {"0:X5" = 0xfffffffffffffffe}]}

--- a/cli/tests/errors/errors.t
+++ b/cli/tests/errors/errors.t
@@ -149,3 +149,24 @@ Isla function error in final assertion
   File "final-isla-fn-error.litmus.toml", path "final.assertion":
   function: unknown unknown_fn/1
   [1]
+
+Negative Isla final assertion
+  $ archsem seq negative-final.litmus.toml
+  archsem: eval error:
+  File "negative-final.litmus.toml", path "final.assertion":
+  final assertion values must be non-negative: -0x1
+  [1]
+
+Negative Isla string memory initialization
+  $ archsem seq negative-location.litmus.toml
+  archsem: eval error:
+  File "negative-location.litmus.toml", path "locations.x":
+  negative memory data is not allowed: -0x1
+  [1]
+
+Negative zero extension in Isla function
+  $ archsem seq negative-extz.litmus.toml
+  archsem: eval error:
+  File "negative-extz.litmus.toml", path "thread.0.init.R0":
+  function: extz: argument bits must be non-negative
+  [1]

--- a/cli/tests/errors/negative-extz.litmus.toml
+++ b/cli/tests/errors/negative-extz.litmus.toml
@@ -1,0 +1,6 @@
+arch = "AArch64"
+name = "negative-extz"
+
+[thread.0]
+init = { X0 = "extz(-1, 64)" }
+code = "NOP"

--- a/cli/tests/errors/negative-final.litmus.toml
+++ b/cli/tests/errors/negative-final.litmus.toml
@@ -1,0 +1,9 @@
+arch = "AArch64"
+name = "negative-final"
+
+[thread.0]
+init = { X0 = "-1" }
+code = "NOP"
+
+[final]
+assertion = "0:X0 = -1"

--- a/cli/tests/errors/negative-location.litmus.toml
+++ b/cli/tests/errors/negative-location.litmus.toml
@@ -1,0 +1,9 @@
+arch = "AArch64"
+name = "negative-location"
+symbolic = ["x"]
+
+[thread.0]
+code = "NOP"
+
+[locations]
+x = "-1"


### PR DESCRIPTION
- Add unary minus support to Isla string terms.
- Convert lexer failures into TOML errors.
- Cover negative string init and unsupported sign extension through CLI tests.