### PR TITLE
feat(Isla): Add basic page table functions

### DIFF
--- a/cli/lib/isla/fn_registry.ml
+++ b/cli/lib/isla/fn_registry.ml
@@ -57,9 +57,34 @@ let int_arg name arg value =
   | n -> n
   | exception Z.Overflow -> error "%s: argument %s is too large" name arg
 
+(** Report a positional arity mismatch for [name]. *)
 let arity_error name expected actual =
   error "%s: expected %d arguments, got %d" name expected actual
 
+(** Check that only allowed kwarg are present, and not duplicated. *)
+let check_kwargs name allowed_args kwargs =
+  List.fold_left
+    (fun seen (arg, _) ->
+       if not (List.mem arg allowed_args) then
+         error "%s: unknown argument %s" name arg
+       else if List.mem arg seen then error "%s: duplicate argument %s" name arg
+       else arg :: seen
+     )
+    [] kwargs
+  |> ignore
+
+(** Extract a required argument from an argument list *)
+let required_kwarg name arg kwargs =
+  match List.assoc_opt arg kwargs with
+  | Some value -> value
+  | None -> error "%s: missing argument %s" name arg
+
+(** Extract an optional named argumen from a list, otherwise gives a default
+    value *)
+let optional_kwarg arg default kwargs =
+  match List.assoc_opt arg kwargs with Some value -> value | None -> default
+
+(** Evaluates a named isla function given a registry and arguments *)
 let eval ~fns name args =
   match List.assoc_opt name fns with
   | Some eval -> eval args

--- a/cli/lib/isla/page_table/page_table_desc.ml
+++ b/cli/lib/isla/page_table/page_table_desc.ml
@@ -167,6 +167,21 @@ let page_descriptor pa kind fields =
   let desc = Int64.logor (Int64.logor pa base_attrs) 0x3L in
   apply_descriptor_fields desc fields
 
+(** Encode a block descriptor for a non-leaf page-table level. *)
+let block_descriptor pa level kind fields =
+  let shift = level_shift level in
+  let mask = Int64.logand addr_mask (Int64.shift_left (-1L) shift) in
+  let pa = Int64.of_int pa in
+  require_in_mask "pa" mask pa;
+  let base_attrs = attrs_of_kind kind in
+  require_in_mask "attrs" attr_mask base_attrs;
+  let desc = Int64.logor (Int64.logor pa base_attrs) 0x1L in
+  apply_descriptor_fields desc fields
+
+let make_descriptor ?(fields = []) ~level ~oa ~kind () =
+  if level = last_level then page_descriptor oa kind fields
+  else block_descriptor oa level kind fields
+
 (** {1 Entry encoding}
 
     Each table entry stores one descriptor value as a 64-bit little-endian word. *)

--- a/cli/lib/isla/page_table/page_table_fns.ml
+++ b/cli/lib/isla/page_table/page_table_fns.ml
@@ -38,28 +38,70 @@
 (*                                                                            *)
 (******************************************************************************)
 
-(** Isla value terms: AST for constant expressions. *)
+(** Page-table helper functions available in Isla expressions. *)
 
-type t =
-  | Const of Z.t
-  | Sym of string
-  | Fn of string * t list
-  | KwFn of string * (string * t) list
+(** [page(a)] extracts a 4KB page number from an address. *)
+let page_function =
+  ( "page",
+    function
+    | [a] -> Z.extract a 12 36
+    | args -> Fn_registry.arity_error "page" 1 (List.length args)
+  )
 
-let zero = Const Z.zero
+(** [asid(v)] shifts an ASID value into bits [63:48]. *)
+let asid_function =
+  ( "asid",
+    function
+    | [v] -> Z.shift_left v 48
+    | args -> Fn_registry.arity_error "asid" 1 (List.length args)
+  )
+
+let descriptor_field_arg kwargs field_name default =
+  { Page_table_ast.name = field_name;
+    value = Fn_registry.optional_kwarg field_name default kwargs
+  }
+
+(** [mkdescN(oa=..., ...)] encodes a level-[N] block/page descriptor. *)
+let eval_desc name level kwargs =
+  Fn_registry.check_kwargs name ["oa"; "Valid"; "AF"; "AP"; "DBM"] kwargs;
+  let oa = Fn_registry.required_kwarg name "oa" kwargs in
+  let fields =
+    [ descriptor_field_arg kwargs "Valid" Z.one;
+      descriptor_field_arg kwargs "AF" Z.one;
+      descriptor_field_arg kwargs "AP" Z.one;
+      descriptor_field_arg kwargs "DBM" Z.zero
+    ]
+  in
+  Z.of_int64
+    (Page_table_desc.make_descriptor ~level
+       ~oa:(Fn_registry.int_arg name "oa" oa)
+       ~kind:Page_table_ast.Data ~fields ()
+    )
+
+(** [mkdescN(table=...)] encodes a next-level table descriptor. *)
+let eval_table_desc name kwargs =
+  Fn_registry.check_kwargs name ["table"] kwargs;
+  let table_addr = Fn_registry.required_kwarg name "table" kwargs in
+  Z.of_int64
+    (Page_table_desc.table_descriptor
+       (Fn_registry.int_arg name "table" table_addr)
+    )
+
+let mkdesc_function level =
+  let name = Printf.sprintf "mkdesc%d" level in
+  let eval kwargs =
+    match (List.mem_assoc "oa" kwargs, List.mem_assoc "table" kwargs) with
+    | (true, false) -> eval_desc name level kwargs
+    | (false, true) -> eval_table_desc name kwargs
+    | _ ->
+        Fn_registry.error "%s: Having both oa and table arguments is not allowed"
+          name
+  in
+  (name, eval)
 
 let positional_functions : Fn_registry.positional_fn list =
-  Bv_fns.functions @ Page_table_fns.positional_functions
+  [page_function; asid_function]
 
 let keyword_functions : Fn_registry.keyword_fn list =
-  Page_table_fns.keyword_functions
-
-let rec eval ~lookup_addr = function
-  | Const z -> z
-  | Sym sym -> Z.of_int (lookup_addr sym)
-  | Fn (name, args) ->
-      let evaluated = List.map (eval ~lookup_addr) args in
-      Fn_registry.eval ~fns:positional_functions name evaluated
-  | KwFn (name, kwargs) ->
-      let evaluated = List.map (fun (k, v) -> (k, eval ~lookup_addr v)) kwargs in
-      Fn_registry.eval ~fns:keyword_functions name evaluated
+  let levels = [0; 1; 2; 3] in
+  List.map mkdesc_function levels

--- a/cli/tests/errors/errors.t
+++ b/cli/tests/errors/errors.t
@@ -136,6 +136,13 @@ Extra Isla function argument
   function: bvor: expected 2 arguments, got 3
   [1]
 
+No matching Isla function overload
+  $ archsem seq no-matching-isla-fn-overload.litmus.toml
+  archsem: eval error:
+  File "no-matching-isla-fn-overload.litmus.toml", path "locations.x":
+  function: mkdesc2: Having both oa and table arguments is not allowed
+  [1]
+
 Isla function error in register initialization
   $ archsem seq init-isla-fn-error.litmus.toml
   archsem: eval error:

--- a/cli/tests/errors/no-matching-isla-fn-overload.litmus.toml
+++ b/cli/tests/errors/no-matching-isla-fn-overload.litmus.toml
@@ -1,0 +1,15 @@
+arch = "AArch64"
+name = "no-matching-isla-fn-overload"
+symbolic = ["x"]
+
+[thread.0]
+code = """
+    NOP
+"""
+
+[locations]
+x = "mkdesc2(oa=0x1000, table=extz(0x283000, 64))"
+
+[final]
+expect = "sat"
+assertion = "true"


### PR DESCRIPTION
<!-- start jj-vine stack -->
This PR is part of a stack containing 3 PRs:

1. `feature/pgt-dsl-attribute`
2. **"feat(Isla): Add basic page table functions" (this PR)**
3. #154
4. #155
<!-- end jj-vine stack -->

## Summary
Supports the following Isla functions:

- `page(a)`
- `asid(v)`
- `mkdescN(oa=..., Valid=..., AF=..., AP=..., DBM=...)`
- `mkdescN(table=...)`

where `N` is `0`, `1`, `2`, or `3`.