### PR TITLE
feat(Isla): Add page table functions - Extended

### DIFF
--- a/cli/lib/isla/allocator.ml
+++ b/cli/lib/isla/allocator.ml
@@ -46,6 +46,8 @@ let default_base = 0x1000
 
 let page_size = 0x1000
 
+let big_size = 1 lsl 21
+
 let align_up addr alignment =
   if alignment <= 0 then
     Litmus.Error.fatal "allocator: alignment must be positive";
@@ -71,6 +73,4 @@ let alloc_page allocator =
   alloc_aligned allocator ~size:page_size ~alignment:page_size
 
 let alloc_big allocator =
-  (* 2MB block. *)
-  let big_size = 1 lsl 21 in
   alloc_aligned allocator ~size:big_size ~alignment:big_size

--- a/cli/lib/isla/allocator.mli
+++ b/cli/lib/isla/allocator.mli
@@ -45,6 +45,9 @@ type t
 (** Size of one page allocated by [alloc_page]. *)
 val page_size : int
 
+(** Size of one block (2MB) allocated by [alloc_big]. *)
+val big_size : int
+
 (** Make an allocator, optionally with reserved addresses. Each reserved
     address blocks the page containing it. *)
 val make : ?base:int -> ?reserved:int list -> unit -> t

--- a/cli/lib/isla/converter.ml
+++ b/cli/lib/isla/converter.ml
@@ -98,9 +98,11 @@ let eval_error context fmt =
     (fun msg -> raise (Eval_error (eval_context_path context, msg)))
     fmt
 
-let eval_term ~context ~lookup_addr term =
+let eval_term ?page_table_va_base ?page_table_entries ~context ~lookup_addr term =
   try
-    let value = Term.eval ~lookup_addr term in
+    let value =
+      Term.eval ?page_table_va_base ?page_table_entries ~lookup_addr term
+    in
     match context with
     (* Final constants stay raw Z.t; registers read via bv_unsigned. *)
     | Final_assertion when Z.sign value < 0 ->
@@ -176,9 +178,11 @@ let find_section name (asm_result : Assembler.assembly_result) =
 (* Build per-thread initial register maps: PC + user init + config defaults. *)
 let build_registers
       ~arch
+      ?page_table_va_base
+      ?page_table_entries
+      ?page_table_root
       ~lookup_addr
       ~pc
-      ?page_table_root
       (start_pc : int)
       (thread : Ir.thread)
   =
@@ -187,7 +191,12 @@ let build_registers
     List.map
       (fun (reg, value) ->
          let context = Register_init (thread.tid, reg) in
-         let gen = RegValGen.Number (eval_term ~context ~lookup_addr value) in
+         let gen =
+           RegValGen.Number
+             (eval_term ?page_table_va_base ?page_table_entries ~context
+                ~lookup_addr value
+             )
+         in
          (reg, normalize_register_gen ~arch ~context reg gen)
        )
       thread.init
@@ -209,8 +218,10 @@ let build_registers
 
 let build_threads
       ~arch
-      ~lookup_addr
+      ?page_table_va_base
+      ?page_table_entries
       ?page_table_root
+      ~lookup_addr
       asm_result
       (threads : Ir.thread list) : Testrepr.thread list
   =
@@ -219,7 +230,8 @@ let build_threads
     (fun tid (thread : Ir.thread) ->
        let sec = find_section (thread_section_name tid) asm_result in
        let regs =
-         build_registers ~arch ~lookup_addr ~pc ?page_table_root sec.addr thread
+         build_registers ~arch ?page_table_va_base ?page_table_entries
+           ?page_table_root ~lookup_addr ~pc sec.addr thread
        in
        let breakpoints = [Z.of_int (sec.addr + Bytes.length sec.data)] in
        {Testrepr.regs; breakpoints}
@@ -229,7 +241,7 @@ let build_threads
 (** {2 Page table setup construction} *)
 
 (* Build the page-table layout from concrete section/symbol VAs.
-  Thread code pages are included so the DSL can request code mappings. *)
+   Thread code pages are included so the DSL can request code mappings. *)
 let build_page_table_setup ir allocator asm_result =
   match ir.Ir.page_table_setup with
   | [] -> None
@@ -254,15 +266,17 @@ let build_page_table_setup ir allocator asm_result =
       with Page_table_builder.Error msg -> eval_error Page_table_setup "%s" msg
     )
 
-(* Terms may refer to VA-side symbols from assembly and PA-side aliases created
-   by page_table_setup. *)
+(* Terms may refer to VA-side assembly symbols, the page-table VA window, and
+   PA-side symbols created by page_table_setup. *)
 let build_lookup_addr asm_result page_table =
-  let symbols_pa =
+  let page_table_symbols =
     match page_table with
     | None -> []
-    | Some layout -> layout.Page_table_builder.symbols_pa
+    | Some layout ->
+        ("page_table_va_base", layout.Page_table_builder.va_base)
+        :: layout.Page_table_builder.symbols_pa
   in
-  let symbols_addr = asm_result.Assembler.symbols @ symbols_pa in
+  let symbols_addr = asm_result.Assembler.symbols @ page_table_symbols in
   fun name ->
     match List.assoc_opt name symbols_addr with
     | Some addr -> addr
@@ -368,13 +382,19 @@ let to_testrepr ~filename (ir : Ir.t) : Testrepr.t =
   let asm_input = to_assembly_input allocator ir in
   let asm_result = Assembler.assemble ~filename asm_input in
   let page_table = build_page_table_setup ir allocator asm_result in
+  let page_table_entries =
+    Option.map (fun layout -> layout.Page_table_builder.table_entries) page_table
+  in
+  let page_table_va_base =
+    Option.map (fun layout -> layout.Page_table_builder.va_base) page_table
+  in
   let lookup_addr = build_lookup_addr asm_result page_table in
   let page_table_root =
     Option.map (fun layout -> layout.Page_table_builder.root) page_table
   in
   let threads =
-    build_threads ~arch:ir.arch ~lookup_addr ?page_table_root asm_result
-      ir.threads
+    build_threads ~arch:ir.arch ?page_table_va_base ?page_table_entries
+      ?page_table_root ~lookup_addr asm_result ir.threads
   in
   let memory =
     build_memory ~mem_size ~data_symbols:asm_input.symbols ~lookup_addr
@@ -387,6 +407,8 @@ let to_testrepr ~filename (ir : Ir.t) : Testrepr.t =
     kind = ir.kind;
     final =
       Assertion.map_cst
-        (eval_term ~context:Final_assertion ~lookup_addr)
+        (eval_term ?page_table_va_base ?page_table_entries
+           ~context:Final_assertion ~lookup_addr
+        )
         ir.assertion
   }

--- a/cli/lib/isla/page_table/page_table_builder.ml
+++ b/cli/lib/isla/page_table/page_table_builder.ml
@@ -54,6 +54,7 @@ type data_value = Z.t
 
 type layout =
   { root : pa;
+    va_base : va;
     table_entries : (pa * descriptor) list;
     symbols_pa : (string * pa) list;
     phys_symbols_pa : (string * pa) list;
@@ -67,6 +68,7 @@ let error fmt = Printf.ksprintf (fun msg -> raise (Error msg)) fmt
 type t =
   { allocator : Allocator.t;
     root : pa;
+    mutable next_table_pa : pa;
     mutable tables : (pa * table) list;
     mutable symbols_pa : (string * pa) list;
     mutable data_inits : (pa * data_value) list
@@ -76,7 +78,13 @@ let empty_table () = Bytes.make Desc.table_size '\x00'
 
 let make allocator ~root =
   let tables = [(root, empty_table ())] in
-  {allocator; tables; root; symbols_pa = []; data_inits = []}
+  { allocator;
+    tables;
+    root;
+    next_table_pa = root + Allocator.page_size;
+    symbols_pa = [];
+    data_inits = []
+  }
 
 let check_arch = function
   | Litmus.Arch_id.Arm -> ()
@@ -96,7 +104,10 @@ let alloc_pa builder name =
 
 (** Allocate a fresh table page and remember its backing bytes. *)
 let create_table_page builder =
-  let addr = Allocator.alloc_page builder.allocator in
+  if builder.next_table_pa >= builder.root + Allocator.big_size then
+    error "page_table: 2MB page-table pool exhausted";
+  let addr = builder.next_table_pa in
+  builder.next_table_pa <- addr + Allocator.page_size;
   let table = empty_table () in
   builder.tables <- (addr, table) :: builder.tables;
   (addr, table)
@@ -135,19 +146,30 @@ let write_leaf table idx va desc =
   Desc.write_entry table idx desc
 
 (** Add the requested mapping, allocating intermediate tables on demand. *)
-let add_mapping ?(fields = []) builder ~va ~pa kind =
-  let va = Desc.align_page_addr va in
-  let pa = Desc.align_page_addr pa in
+let add_mapping ?(fields = []) ?(level = Desc.last_level) builder ~va ~pa kind =
+  (* Check address alignment based on the mapping size. *)
+  let mapping_size = 1 lsl Desc.level_shift level in
+  let (va, pa) =
+    if level = Desc.last_level then
+      (Desc.align_page_addr va, Desc.align_page_addr pa)
+    else (
+      if va mod mapping_size <> 0 then
+        error "page_table: VA 0x%x is not aligned for a level %d mapping" va level;
+      if pa mod mapping_size <> 0 then
+        error "page_table: PA 0x%x is not aligned for a level %d mapping" pa level;
+      (va, pa)
+    )
+  in
   let desc =
-    try Desc.page_descriptor pa kind fields
+    try Desc.make_desc ~fields ~level ~oa:pa ~kind ()
     with Failure msg -> error "page_table: %s" msg
   in
-  let rec walk table level =
-    let idx = Desc.va_index va level in
-    if level = Desc.last_level then write_leaf table idx va desc
+  let rec walk table current_level =
+    let idx = Desc.va_index va current_level in
+    if current_level = level then write_leaf table idx va desc
     else
       let child_table = ensure_child_table builder table idx in
-      walk child_table (level + 1)
+      walk child_table (current_level + 1)
   in
   let root_table = find_table builder.tables builder.root in
   walk root_table Desc.root_level
@@ -199,27 +221,32 @@ let to_entries builder =
     builder.tables
 
 (** Freeze the builder state into the immutable layout used downstream. *)
-let to_layout builder =
+let to_layout ~va_base builder =
   let root = builder.root in
   let table_entries = to_entries builder in
+  (* Generated PA alias for the root translation-table page. *)
   let symbols_pa = ("page_table_base", root) :: builder.symbols_pa in
   let phys_symbols_pa = List.rev builder.symbols_pa in
   let data_inits = builder.data_inits in
-  {root; table_entries; symbols_pa; phys_symbols_pa; data_inits}
+  {root; va_base; table_entries; symbols_pa; phys_symbols_pa; data_inits}
 
 let build ~arch ~allocator ~symbolic_vas ~code_pages stmts =
   check_arch arch;
   if stmts = [] then error "page_table: empty page_table_setup";
-  (* Allocate the root before evaluating statements *)
-  let root = Allocator.alloc_page allocator in
+  (* [root] is the TTBR0 value and the base of the 2MB physical page-table pool.
+     [va_base] is the VA window used to access that pool. *)
+  let root = Allocator.alloc_big allocator in
+  let va_base = Allocator.alloc_big allocator in
   let builder = make allocator ~root in
+  (* Make the page-table pool accessible through [va_base]. *)
+  add_mapping ~level:2 builder ~va:va_base ~pa:root Page_table_ast.Data;
   (* Evaluate each statement, using symbolic VAs to resolve virtual names. *)
   List.iter (eval_stmt builder ~symbolic_vas) stmts;
   (* Add code identity mappings after explicit page-table statements. *)
   add_code_mappings builder code_pages;
   (* Put data initializers back in source order. *)
   builder.data_inits <- List.rev builder.data_inits;
-  to_layout builder
+  to_layout ~va_base builder
 
 (** {1 Layout queries} *)
 
@@ -239,9 +266,10 @@ let translate_va_to_pa layout va =
     | Some desc -> (
       match Desc.table_addr_of_descriptor desc with
       | Some table -> walk table (level + 1)
-      | None ->
-          error "page_table: expected table descriptor for VA 0x%x at level %d" va
-            level
+      | None when Int64.logand desc 0x1L <> 0L ->
+          let block_size = 1 lsl Desc.level_shift level in
+          Some (Desc.addr_of_descriptor desc + (va mod block_size))
+      | None -> None
     )
   in
   walk layout.root Desc.root_level

--- a/cli/lib/isla/page_table/page_table_builder.mli
+++ b/cli/lib/isla/page_table/page_table_builder.mli
@@ -53,6 +53,8 @@ type data_value = Z.t
 
 type layout =
   { root : pa;
+    (* Base VA of the 2MB window that maps the page-table pool. *)
+    va_base : va;
     table_entries : (pa * descriptor) list;
     (* Mapping from PA-side symbols to concrete PAs: pa_x -> PA. *)
     symbols_pa : (string * pa) list;

--- a/cli/lib/isla/page_table/page_table_fns.ml
+++ b/cli/lib/isla/page_table/page_table_fns.ml
@@ -40,6 +40,23 @@
 
 (** Page-table helper functions available in Isla expressions. *)
 
+(** Return the PA of the PTE selected by [va] at [level], walking table
+    entries from the root translation-table PA [base]. *)
+let pte_addr name entries ~base ~va ~level =
+  let rec walk table current_level =
+    let index = Page_table_desc.va_index va current_level in
+    let addr = table + (index * Page_table_desc.entry_size) in
+    if current_level = level then addr
+    else
+      let desc = List.assoc_opt addr entries |> Option.value ~default:0L in
+      match Page_table_desc.table_addr_of_descriptor desc with
+      | Some next_table -> walk next_table (current_level + 1)
+      | None ->
+          Fn_registry.error "%s: no table descriptor at level %d for VA 0x%x" name
+            current_level va
+  in
+  walk base Page_table_desc.root_level
+
 (** [page(a)] extracts a 4KB page number from an address. *)
 let page_function =
   ( "page",
@@ -67,8 +84,56 @@ let asid_function =
     }
   )
 
+(** [pteN(va, base)] treats [base] as the root translation-table PA, then
+    returns the VA of the matching PTE in the page-table VA window. *)
+let pte_function page_table_va_base entries level =
+  let name = Printf.sprintf "pte%d" level in
+  ( name,
+    { Fn_registry.params = ["va"; "base"];
+      defaults = [];
+      eval =
+        (function
+          | [va; base] ->
+              let va = Fn_registry.int_arg name "va" va in
+              let root = Fn_registry.int_arg name "base" base in
+              let pte_pa = pte_addr name entries ~base:root ~va ~level in
+              (* [pte_pa] is a PA; VM code needs the VA for the same entry in
+                 the page-table pool window. *)
+              let offset = pte_pa - root in
+              if offset < 0 || offset >= Allocator.big_size then
+                Fn_registry.error
+                  "%s: PTE PA 0x%x is outside page-table pool rooted at 0x%x" name
+                  pte_pa root;
+              Z.of_int (page_table_va_base + offset)
+          | args -> Fn_registry.arity_error name 2 (List.length args)
+          )
+    }
+  )
+
+(** [descN(va, base)] treats [base] as the root translation-table PA and
+    returns the descriptor stored in the matching level-[N] PTE. *)
+let desc_function entries level =
+  let name = Printf.sprintf "desc%d" level in
+  ( name,
+    { Fn_registry.params = ["va"; "base"];
+      defaults = [];
+      eval =
+        (function
+          | [va; base] ->
+              let addr =
+                pte_addr name entries
+                  ~base:(Fn_registry.int_arg name "base" base)
+                  ~va:(Fn_registry.int_arg name "va" va)
+                  ~level
+              in
+              Z.of_int64 (List.assoc_opt addr entries |> Option.value ~default:0L)
+          | args -> Fn_registry.arity_error name 2 (List.length args)
+          )
+    }
+  )
+
 (** [mkdescN(oa=..., ...)] encodes a level-[N] block/page descriptor. *)
-let make_desc_function level =
+let mkdesc_function level =
   let name = Printf.sprintf "mkdesc%d" level in
   ( name,
     { Fn_registry.params = ["oa"; "Valid"; "AF"; "AP"; "DBM"];
@@ -94,7 +159,7 @@ let make_desc_function level =
   )
 
 (** [mkdescN(table=...)] encodes a next-level table descriptor. *)
-let make_table_desc_function level =
+let mkdesc_table_function level =
   let name = Printf.sprintf "mkdesc%d" level in
   ( name,
     { Fn_registry.params = ["table"];
@@ -111,8 +176,10 @@ let make_table_desc_function level =
     }
   )
 
-let functions =
+let functions ~page_table_va_base ~page_table_entries () =
   let levels = [0; 1; 2; 3] in
   [page_function; asid_function]
-  @ List.map make_desc_function levels
-  @ List.map make_table_desc_function levels
+  @ List.map (pte_function page_table_va_base page_table_entries) levels
+  @ List.map (desc_function page_table_entries) levels
+  @ List.map mkdesc_function levels
+  @ List.map mkdesc_table_function levels

--- a/cli/lib/isla/term.ml
+++ b/cli/lib/isla/term.ml
@@ -48,14 +48,30 @@ type t =
 
 let zero = Const Z.zero
 
-let builtins = Bv_fns.functions @ Page_table_fns.functions
+let functions ?page_table_va_base ?page_table_entries () =
+  (* Page-table functions need the concrete layout produced by page_table_setup.
+     Keep them unavailable for ordinary term evaluation. *)
+  let page_table_fns =
+    match (page_table_va_base, page_table_entries) with
+    | (Some page_table_va_base, Some page_table_entries) ->
+        Page_table_fns.functions ~page_table_va_base ~page_table_entries ()
+    | (None, _) -> []
+    | (Some _, None) ->
+        Litmus.Error.failwith
+          "page_table_entries missing for page-table function evaluation"
+  in
+  Bv_fns.functions @ page_table_fns
 
-let rec eval ~lookup_addr = function
-  | Const z -> z
-  | Sym sym -> Z.of_int (lookup_addr sym)
-  | Fn (name, args) ->
-      let evaluated = List.map (eval ~lookup_addr) args in
-      Fn_registry.eval_fn ~fns:builtins name evaluated
-  | KwFn (name, kwargs) ->
-      let evaluated = List.map (fun (k, v) -> (k, eval ~lookup_addr v)) kwargs in
-      Fn_registry.eval_kwfn ~fns:builtins name evaluated
+let eval ?page_table_va_base ?page_table_entries ~lookup_addr term =
+  let fns = functions ?page_table_va_base ?page_table_entries () in
+  let rec eval_term = function
+    | Const z -> z
+    | Sym sym -> Z.of_int (lookup_addr sym)
+    | Fn (name, args) ->
+        let evaluated = List.map eval_term args in
+        Fn_registry.eval_fn ~fns name evaluated
+    | KwFn (name, kwargs) ->
+        let evaluated = List.map (fun (k, v) -> (k, eval_term v)) kwargs in
+        Fn_registry.eval_kwfn ~fns name evaluated
+  in
+  eval_term term

--- a/cli/tests/arm/vm/MP+VM.litmus.toml
+++ b/cli/tests/arm/vm/MP+VM.litmus.toml
@@ -9,7 +9,7 @@ x ?-> pa_y;
 """
 
 [thread.0]
-init = { X0 = 1, X1 = "x", X2 = 1, X3 = "y", SCTLR_EL1 = 1, CurrentEL = 1 }
+init = { X0 = 1, X1 = "x", X2 = 1, X3 = "y", X4 = "pte3(x, page_table_base)", X5 = "desc3(x, page_table_base)", X6 = "mkdesc3(oa=pa_y, Valid=0b0, AF=0b0, AP=0b11, DBM=0b1)", SCTLR_EL1 = 1, CurrentEL = 1 }
 code = """
 	STR X0,[X1]
 	STR X2,[X3]
@@ -24,4 +24,4 @@ code = """
 
 [final]
 expect = "sat"
-assertion = "1:X0 = 1 & 1:X2 = 0"
+assertion = "1:X0 = 1 & 1:X2 = 0 & 0:X4 = 0x403018 & 0:X5 = 0x600443 & 0:X6 = 0x80000006010c2"

--- a/cli/tests/converter/expect/arm/vm/Alias+VM.litmus.toml
+++ b/cli/tests/converter/expect/arm/vm/Alias+VM.litmus.toml
@@ -10,43 +10,49 @@ name = "Alias+VM"
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9008
+  addr = 0x203008
   step = 8
   data = 0x14c3
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9010
+  addr = 0x203010
   step = 8
-  data = 0x6443
+  data = 0x600443
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9018
+  addr = 0x203018
   step = 8
-  data = 0x6443
+  data = 0x600443
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x8000
+  addr = 0x202000
   step = 8
-  data = 0x9003
+  data = 0x203003
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x7000
+  addr = 0x202010
   step = 8
-  data = 0x8003
+  data = 0x200441
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x5000
+  addr = 0x201000
   step = 8
-  data = 0x7003
+  data = 0x202003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x200000
+  step = 8
+  data = 0x201003
 
 [[memory]]
   sym = "pa_x"
-  addr = 0x6000
+  addr = 0x600000
   step = 8
   data = 0
 
@@ -60,7 +66,7 @@ name = "Alias+VM"
   "R0" = 1
   "R1" = 0x2000
   "R2" = 0x3000
-  "TTBR0_EL1" = 0x5000
+  "TTBR0_EL1" = 0x200000
   "SCTLR_EL1" = 1
   CurrentEL = 1
   "R3" = 0

--- a/cli/tests/converter/expect/arm/vm/MP+VM.litmus.toml
+++ b/cli/tests/converter/expect/arm/vm/MP+VM.litmus.toml
@@ -17,55 +17,61 @@ name = "MP+VM"
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9008
+  addr = 0x203008
   step = 8
   data = 0x14c3
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9010
+  addr = 0x203010
   step = 8
   data = 0x24c3
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9018
+  addr = 0x203018
   step = 8
-  data = 0x6443
+  data = 0x600443
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9020
+  addr = 0x203020
   step = 8
-  data = 0xa443
+  data = 0x601443
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x8000
+  addr = 0x202000
   step = 8
-  data = 0x9003
+  data = 0x203003
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x7000
+  addr = 0x202010
   step = 8
-  data = 0x8003
+  data = 0x200441
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x5000
+  addr = 0x201000
   step = 8
-  data = 0x7003
+  data = 0x202003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x200000
+  step = 8
+  data = 0x201003
 
 [[memory]]
   sym = "pa_x"
-  addr = 0x6000
+  addr = 0x600000
   step = 8
   data = 0
 
 [[memory]]
   sym = "pa_y"
-  addr = 0xa000
+  addr = 0x601000
   step = 8
   data = 0
 
@@ -80,12 +86,12 @@ name = "MP+VM"
   "R1" = 0x3000
   "R2" = 1
   "R3" = 0x4000
+  "R4" = 0x403018
+  "R5" = 0x600443
+  "R6" = 0x80000006010c2
   "SCTLR_EL1" = 1
   CurrentEL = 1
-  "TTBR0_EL1" = 0x5000
-  "R4" = 0
-  "R5" = 0
-  "R6" = 0
+  "TTBR0_EL1" = 0x200000
   "R7" = 0
   "R8" = 0
   "R9" = 0
@@ -125,7 +131,7 @@ name = "MP+VM"
   "R3" = 0x3000
   "SCTLR_EL1" = 1
   CurrentEL = 1
-  "TTBR0_EL1" = 0x5000
+  "TTBR0_EL1" = 0x200000
   "R0" = 0
   "R2" = 0
   "R4" = 0
@@ -162,4 +168,4 @@ name = "MP+VM"
   DAIF = 0
 
 [final]
-  assertion = {and = [{"1:X0" = 1}, {"1:X2" = 0}]}
+  assertion = {and = [{"1:X0" = 1}, {"1:X2" = 0}, {"0:X4" = 0x403018}, {"0:X5" = 0x600443}, {"0:X6" = 0x80000006010c2}]}

--- a/cli/tests/errors/errors.t
+++ b/cli/tests/errors/errors.t
@@ -139,7 +139,7 @@ Duplicate Isla function argument
 No matching Isla function overload
   $ archsem seq no-matching-isla-fn-overload.litmus.toml
   archsem: eval error:
-  File "no-matching-isla-fn-overload.litmus.toml", path "locations.x":
+  File "no-matching-isla-fn-overload.litmus.toml", path "thread.0.init.R0":
   function: no matching overload for mkdesc2
   [1]
 
@@ -196,7 +196,7 @@ Page table DSL rejects duplicate VA mappings
   $ archsem seq conflicting-page-table-mapping.litmus.toml
   archsem: eval error:
   File "conflicting-page-table-mapping.litmus.toml", path "page_table_setup":
-  page_table: conflicting mapping for VA 0x2000: existing descriptor 0x4443, new descriptor 0x5443
+  page_table: conflicting mapping for VA 0x2000: existing descriptor 0x600443, new descriptor 0x601443
   [1]
 
 Page table DSL rejects locations with page tables

--- a/cli/tests/errors/no-matching-isla-fn-overload.litmus.toml
+++ b/cli/tests/errors/no-matching-isla-fn-overload.litmus.toml
@@ -1,14 +1,15 @@
 arch = "AArch64"
 name = "no-matching-isla-fn-overload"
-symbolic = ["x"]
+
+page_table_setup = """
+physical pa_x;
+"""
 
 [thread.0]
+init = { R0 = "mkdesc2(oa=0x1000, table=extz(0x283000, 64))" }
 code = """
     NOP
 """
-
-[locations]
-x = "mkdesc2(oa=0x1000, table=extz(0x283000, 64))"
 
 [final]
 expect = "sat"


### PR DESCRIPTION
On top of #151, this PR supports
- `pteN(va, base)`, returning a VA that can be used as a memory operand for the matching PTE
- `descN(va, base)`, returning the descriptor value stored in the generated page table

To implement these functions, generated page-table pages now live in a preallocated 2MB page-table pool rooted at `page_table_base`. There is no way to expand that pool yet. The converter also creates a `va_base` mapping for that pool, so `pteN` can return a usable VA for the selected PTE.
