### PR TITLE
feat(Isla): Identity-map page table pool

### DIFF
--- a/cli/lib/isla/allocator.ml
+++ b/cli/lib/isla/allocator.ml
@@ -46,6 +46,8 @@ let default_base = 0x1000
 
 let page_size = 0x1000
 
+let big_size = 1 lsl 21
+
 let align_up addr alignment =
   if alignment <= 0 then
     Litmus.Error.fatal "allocator: alignment must be positive";
@@ -71,6 +73,4 @@ let alloc_page allocator =
   alloc_aligned allocator ~size:page_size ~alignment:page_size
 
 let alloc_big allocator =
-  (* 2MB block. *)
-  let big_size = 1 lsl 21 in
   alloc_aligned allocator ~size:big_size ~alignment:big_size

--- a/cli/lib/isla/allocator.mli
+++ b/cli/lib/isla/allocator.mli
@@ -45,6 +45,9 @@ type t
 (** Size of one page allocated by [alloc_page]. *)
 val page_size : int
 
+(** Size of one block (2MB) allocated by [alloc_big]. *)
+val big_size : int
+
 (** Make an allocator, optionally with reserved addresses. Each reserved
     address blocks the page containing it. *)
 val make : ?base:int -> ?reserved:int list -> unit -> t

--- a/cli/lib/isla/converter.ml
+++ b/cli/lib/isla/converter.ml
@@ -176,9 +176,9 @@ let find_section name (asm_result : Assembler.assembly_result) =
 (* Build per-thread initial register maps: PC + user init + config defaults. *)
 let build_registers
       ~arch
+      ?page_table_root
       ~lookup_addr
       ~pc
-      ?page_table_root
       (start_pc : int)
       (thread : Ir.thread)
   =
@@ -209,8 +209,8 @@ let build_registers
 
 let build_threads
       ~arch
-      ~lookup_addr
       ?page_table_root
+      ~lookup_addr
       asm_result
       (threads : Ir.thread list) : Testrepr.thread list
   =
@@ -219,7 +219,7 @@ let build_threads
     (fun tid (thread : Ir.thread) ->
        let sec = find_section (thread_section_name tid) asm_result in
        let regs =
-         build_registers ~arch ~lookup_addr ~pc ?page_table_root sec.addr thread
+         build_registers ~arch ?page_table_root ~lookup_addr ~pc sec.addr thread
        in
        let breakpoints = [Z.of_int (sec.addr + Bytes.length sec.data)] in
        {Testrepr.regs; breakpoints}
@@ -229,7 +229,7 @@ let build_threads
 (** {2 Page table setup construction} *)
 
 (* Build the page-table layout from concrete section/symbol VAs.
-  Thread code pages are included so the DSL can request code mappings. *)
+   Thread code pages are included so the DSL can request code mappings. *)
 let build_page_table_setup ir allocator asm_result =
   match ir.Ir.page_table_setup with
   | [] -> None
@@ -254,15 +254,15 @@ let build_page_table_setup ir allocator asm_result =
       with Page_table_builder.Error msg -> eval_error Page_table_setup "%s" msg
     )
 
-(* Terms may refer to VA-side symbols from assembly and PA-side aliases created
-   by page_table_setup. *)
+(* Terms may refer to VA-side assembly symbols and PA-side symbols created by
+   page_table_setup. *)
 let build_lookup_addr asm_result page_table =
-  let symbols_pa =
+  let page_table_symbols =
     match page_table with
     | None -> []
     | Some layout -> layout.Page_table_builder.symbols_pa
   in
-  let symbols_addr = asm_result.Assembler.symbols @ symbols_pa in
+  let symbols_addr = asm_result.Assembler.symbols @ page_table_symbols in
   fun name ->
     match List.assoc_opt name symbols_addr with
     | Some addr -> addr
@@ -373,7 +373,7 @@ let to_testrepr ~filename (ir : Ir.t) : Testrepr.t =
     Option.map (fun layout -> layout.Page_table_builder.root) page_table
   in
   let threads =
-    build_threads ~arch:ir.arch ~lookup_addr ?page_table_root asm_result
+    build_threads ~arch:ir.arch ?page_table_root ~lookup_addr asm_result
       ir.threads
   in
   let memory =

--- a/cli/lib/isla/page_table/page_table_builder.ml
+++ b/cli/lib/isla/page_table/page_table_builder.ml
@@ -67,6 +67,7 @@ let error fmt = Printf.ksprintf (fun msg -> raise (Error msg)) fmt
 type t =
   { allocator : Allocator.t;
     root : pa;
+    mutable next_table_pa : pa;
     mutable tables : (pa * table) list;
     mutable symbols_pa : (string * pa) list;
     mutable data_inits : (pa * data_value) list
@@ -76,7 +77,13 @@ let empty_table () = Bytes.make Desc.table_size '\x00'
 
 let make allocator ~root =
   let tables = [(root, empty_table ())] in
-  {allocator; tables; root; symbols_pa = []; data_inits = []}
+  { allocator;
+    tables;
+    root;
+    next_table_pa = root + Allocator.page_size;
+    symbols_pa = [];
+    data_inits = []
+  }
 
 let check_arch = function
   | Litmus.Arch_id.Arm -> ()
@@ -96,7 +103,10 @@ let alloc_pa builder name =
 
 (** Allocate a fresh table page and remember its backing bytes. *)
 let create_table_page builder =
-  let addr = Allocator.alloc_page builder.allocator in
+  if builder.next_table_pa >= builder.root + Allocator.big_size then
+    error "page_table: 2MB page-table pool exhausted";
+  let addr = builder.next_table_pa in
+  builder.next_table_pa <- addr + Allocator.page_size;
   let table = empty_table () in
   builder.tables <- (addr, table) :: builder.tables;
   (addr, table)
@@ -134,20 +144,28 @@ let write_leaf table idx va desc =
        va existing desc;
   Desc.write_entry table idx desc
 
+(** Align a VA or PA for the descriptor level being inserted. *)
+let check_aligned_at_level name level addr =
+  let mapping_size = Desc.level_size level in
+  if addr mod mapping_size = 0 then addr
+  else
+    error "page_table: %s 0x%x is not aligned for a level %d mapping" name addr
+      level
+
 (** Add the requested mapping, allocating intermediate tables on demand. *)
-let add_mapping ?(fields = []) builder ~va ~pa kind =
-  let va = Desc.align_page_addr va in
-  let pa = Desc.align_page_addr pa in
+let add_mapping ?(fields = []) ?(level = Desc.last_level) builder ~va ~pa kind =
+  let va = check_aligned_at_level "VA" level va in
+  let pa = check_aligned_at_level "PA" level pa in
   let desc =
-    try Desc.page_descriptor pa kind fields
+    try Desc.make_descriptor ~fields ~level ~oa:pa ~kind ()
     with Failure msg -> error "page_table: %s" msg
   in
-  let rec walk table level =
-    let idx = Desc.va_index va level in
-    if level = Desc.last_level then write_leaf table idx va desc
+  let rec walk table current_level =
+    let idx = Desc.va_index va current_level in
+    if current_level = level then write_leaf table idx va desc
     else
       let child_table = ensure_child_table builder table idx in
-      walk child_table (level + 1)
+      walk child_table (current_level + 1)
   in
   let root_table = find_table builder.tables builder.root in
   walk root_table Desc.root_level
@@ -202,6 +220,7 @@ let to_entries builder =
 let to_layout builder =
   let root = builder.root in
   let table_entries = to_entries builder in
+  (* Generated PA alias for the root translation-table page. *)
   let symbols_pa = ("page_table_base", root) :: builder.symbols_pa in
   let phys_symbols_pa = List.rev builder.symbols_pa in
   let data_inits = builder.data_inits in
@@ -210,9 +229,11 @@ let to_layout builder =
 let build ~arch ~allocator ~symbolic_vas ~code_pages stmts =
   check_arch arch;
   if stmts = [] then error "page_table: empty page_table_setup";
-  (* Allocate the root before evaluating statements *)
-  let root = Allocator.alloc_page allocator in
+  (* [root] is the TTBR0 value and the base of the 2MB page-table pool. *)
+  let root = Allocator.alloc_big allocator in
   let builder = make allocator ~root in
+  (* Page tables are identity-mapped so generated PTE VAs can access them. *)
+  add_mapping ~level:2 builder ~va:root ~pa:root Page_table_ast.Data;
   (* Evaluate each statement, using symbolic VAs to resolve virtual names. *)
   List.iter (eval_stmt builder ~symbolic_vas) stmts;
   (* Add code identity mappings after explicit page-table statements. *)
@@ -228,20 +249,14 @@ let translate_va_to_pa layout va =
     let idx = Desc.va_index va level in
     List.assoc_opt (table + (idx * Desc.entry_size)) layout.table_entries
   in
-  let page_offset = va - Desc.align_page_addr va in
   let rec walk table level =
     match desc_at table level with
     | None -> None
-    | Some desc when level = Desc.last_level ->
-        if Desc.is_valid desc then
-          Some (Desc.addr_of_descriptor desc + page_offset)
-        else None
-    | Some desc -> (
-      match Desc.table_addr_of_descriptor desc with
-      | Some table -> walk table (level + 1)
-      | None ->
-          error "page_table: expected table descriptor for VA 0x%x at level %d" va
-            level
-    )
+    | Some desc when not (Desc.is_valid desc) -> None
+    | Some desc when Desc.is_table level desc ->
+        walk (Desc.addr_of_descriptor desc) (level + 1)
+    | Some desc ->
+        Some
+          (Desc.addr_of_descriptor desc + (va land Desc.level_offset_mask level))
   in
   walk layout.root Desc.root_level

--- a/cli/lib/isla/page_table/page_table_desc.ml
+++ b/cli/lib/isla/page_table/page_table_desc.ml
@@ -66,12 +66,20 @@ let level_shift = function
   | 3 -> 12
   | n -> Printf.ksprintf invalid_arg "page_table_desc: invalid level %d" n
 
+(** The size of a block at a given level for 4KB AArch64 tables *)
+let level_size level = 1 lsl level_shift level
+
+(** The offset mask for a specific level *)
+let level_offset_mask level = level_size level - 1
+
 (** Extract the 9-bit table index for [va] at [level]. *)
 let va_index va level = (va lsr level_shift level) land 0x1FF
 
 (** {1 Descriptor values}
 
     Attribute bits are stored without the type field (bits 1:0). *)
+
+(** {2 Descriptor fields} *)
 
 type descriptor_field =
   { name : string;
@@ -119,6 +127,8 @@ let apply_descriptor_fields desc fields =
      )
     desc fields
 
+(** {2 Descriptor masks} *)
+
 let addr_mask = 0x0000FFFFFFFFF000L
 
 let low_attr_mask = 0xFFFL
@@ -126,6 +136,31 @@ let low_attr_mask = 0xFFFL
 let desc_type_mask = 0x3L
 
 let attr_mask = Int64.logand low_attr_mask (Int64.lognot desc_type_mask)
+
+(** {2 Descriptor lookup}
+
+    Functions to lookup information from descriptors *)
+
+(** Extract the output address from a table, block, or page descriptor. *)
+let addr_of_descriptor desc = Int64.to_int (Int64.logand desc addr_mask)
+
+(** Return the next table address when [desc] is a table descriptor. *)
+let table_addr_of_descriptor desc =
+  let attrs = Int64.logand desc low_attr_mask in
+  if attrs = 0x3L then Some (addr_of_descriptor desc) else None
+
+(** The AArch64 descriptor Valid bit is bit 0. *)
+let is_valid desc = Int64.logand desc 0x1L <> 0L
+
+(** For a non-level 3 block entry, bit 1 is 0 *)
+let is_block desc = Int64.logand desc 0b10L == 0L
+
+(** Decide if an entry is a table entry*)
+let is_table level desc = level != last_level && not (is_block desc)
+
+(** {2 Descriptor builder}
+
+    Functions to make new descriptors *)
 
 (** Reject values that would set bits outside [mask]. *)
 let require_in_mask name mask value =
@@ -138,21 +173,10 @@ let require_addr_in_mask name addr =
   require_in_mask name addr_mask addr;
   addr
 
-(** Extract the output address from a table, block, or page descriptor. *)
-let addr_of_descriptor desc = Int64.to_int (Int64.logand desc addr_mask)
-
-(** Return the next table address when [desc] is a table descriptor. *)
-let table_addr_of_descriptor desc =
-  let attrs = Int64.logand desc low_attr_mask in
-  if attrs = 0x3L then Some (addr_of_descriptor desc) else None
-
 (** Encode a descriptor that points to the next-level table page. *)
 let table_descriptor next_table_pa =
   let next_table_pa = require_addr_in_mask "next_table_pa" next_table_pa in
   Int64.logor next_table_pa 0x3L
-
-(** The AArch64 descriptor Valid bit is bit 0. *)
-let is_valid desc = Int64.logand desc 0x1L <> 0L
 
 let attrs_of_kind = function
   | Ast.Code -> aarch64_code_attrs

--- a/cli/tests/converter/expect/arm/vm/Alias+VM.litmus.toml
+++ b/cli/tests/converter/expect/arm/vm/Alias+VM.litmus.toml
@@ -10,43 +10,49 @@ name = "Alias+VM"
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9008
+  addr = 0x203008
   step = 8
   data = 0x14c3
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9010
+  addr = 0x203010
   step = 8
-  data = 0x6443
+  data = 0x400443
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9018
+  addr = 0x203018
   step = 8
-  data = 0x6443
+  data = 0x400443
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x8000
+  addr = 0x202000
   step = 8
-  data = 0x9003
+  data = 0x203003
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x7000
+  addr = 0x202008
   step = 8
-  data = 0x8003
+  data = 0x200441
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x5000
+  addr = 0x201000
   step = 8
-  data = 0x7003
+  data = 0x202003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x200000
+  step = 8
+  data = 0x201003
 
 [[memory]]
   sym = "pa_x"
-  addr = 0x6000
+  addr = 0x400000
   step = 8
   data = 0
 
@@ -60,7 +66,7 @@ name = "Alias+VM"
   "R0" = 1
   "R1" = 0x2000
   "R2" = 0x3000
-  "TTBR0_EL1" = 0x5000
+  "TTBR0_EL1" = 0x200000
   "SCTLR_EL1" = 1
   CurrentEL = 1
   "R3" = 0

--- a/cli/tests/converter/expect/arm/vm/MP+VM.litmus.toml
+++ b/cli/tests/converter/expect/arm/vm/MP+VM.litmus.toml
@@ -17,55 +17,61 @@ name = "MP+VM"
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9008
+  addr = 0x203008
   step = 8
   data = 0x14c3
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9010
+  addr = 0x203010
   step = 8
   data = 0x24c3
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9018
+  addr = 0x203018
   step = 8
-  data = 0x6443
+  data = 0x400443
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x9020
+  addr = 0x203020
   step = 8
-  data = 0xa443
+  data = 0x401443
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x8000
+  addr = 0x202000
   step = 8
-  data = 0x9003
+  data = 0x203003
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x7000
+  addr = 0x202008
   step = 8
-  data = 0x8003
+  data = 0x200441
 
 [[memory]]
   kind = "pagetable"
-  addr = 0x5000
+  addr = 0x201000
   step = 8
-  data = 0x7003
+  data = 0x202003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x200000
+  step = 8
+  data = 0x201003
 
 [[memory]]
   sym = "pa_x"
-  addr = 0x6000
+  addr = 0x400000
   step = 8
   data = 0
 
 [[memory]]
   sym = "pa_y"
-  addr = 0xa000
+  addr = 0x401000
   step = 8
   data = 0
 
@@ -82,7 +88,7 @@ name = "MP+VM"
   "R3" = 0x4000
   "SCTLR_EL1" = 1
   CurrentEL = 1
-  "TTBR0_EL1" = 0x5000
+  "TTBR0_EL1" = 0x200000
   "R4" = 0
   "R5" = 0
   "R6" = 0
@@ -125,7 +131,7 @@ name = "MP+VM"
   "R3" = 0x3000
   "SCTLR_EL1" = 1
   CurrentEL = 1
-  "TTBR0_EL1" = 0x5000
+  "TTBR0_EL1" = 0x200000
   "R0" = 0
   "R2" = 0
   "R4" = 0

--- a/cli/tests/errors/errors.t
+++ b/cli/tests/errors/errors.t
@@ -196,7 +196,7 @@ Page table DSL rejects duplicate VA mappings
   $ archsem seq conflicting-page-table-mapping.litmus.toml
   archsem: eval error:
   File "conflicting-page-table-mapping.litmus.toml", path "page_table_setup":
-  page_table: conflicting mapping for VA 0x2000: existing descriptor 0x4443, new descriptor 0x5443
+  page_table: conflicting mapping for VA 0x2000: existing descriptor 0x400443, new descriptor 0x401443
   [1]
 
 Page table DSL rejects locations with page tables


### PR DESCRIPTION
<!-- start jj-vine stack -->
This PR is part of a stack containing 3 PRs:

1. `feature/pgt-dsl-attribute`
2. #151
3. **"feat(Isla): Map page table pool" (this PR)**
4. #155
<!-- end jj-vine stack -->

## Summary

To implement `pteN` function, generated page-table pages now live in a preallocated 2MB page-table pool rooted at `page_table_base`. There is no way to expand that pool yet. The converter also creates a `va_base` mapping for that pool, so `pteN` can return a usable VA for the selected PTE.
