### PR TITLE
feat(Isla): Add page table PTE functions

### DIFF
--- a/cli/lib/isla/converter.ml
+++ b/cli/lib/isla/converter.ml
@@ -98,9 +98,9 @@ let eval_error context fmt =
     (fun msg -> raise (Eval_error (eval_context_path context, msg)))
     fmt
 
-let eval_term ~context ~lookup_addr term =
+let eval_term ?page_table_entries ~context ~lookup_addr term =
   try
-    let value = Term.eval ~lookup_addr term in
+    let value = Term.eval ?page_table_entries ~lookup_addr term in
     match context with
     (* Final constants stay raw Z.t; registers read via bv_unsigned. *)
     | Final_assertion when Z.sign value < 0 ->
@@ -176,6 +176,7 @@ let find_section name (asm_result : Assembler.assembly_result) =
 (* Build per-thread initial register maps: PC + user init + config defaults. *)
 let build_registers
       ~arch
+      ?page_table_entries
       ?page_table_root
       ~lookup_addr
       ~pc
@@ -187,7 +188,10 @@ let build_registers
     List.map
       (fun (reg, value) ->
          let context = Register_init (thread.tid, reg) in
-         let gen = RegValGen.Number (eval_term ~context ~lookup_addr value) in
+         let gen =
+           RegValGen.Number
+             (eval_term ?page_table_entries ~context ~lookup_addr value)
+         in
          (reg, normalize_register_gen ~arch ~context reg gen)
        )
       thread.init
@@ -209,6 +213,7 @@ let build_registers
 
 let build_threads
       ~arch
+      ?page_table_entries
       ?page_table_root
       ~lookup_addr
       asm_result
@@ -219,7 +224,8 @@ let build_threads
     (fun tid (thread : Ir.thread) ->
        let sec = find_section (thread_section_name tid) asm_result in
        let regs =
-         build_registers ~arch ?page_table_root ~lookup_addr ~pc sec.addr thread
+         build_registers ~arch ?page_table_entries ?page_table_root ~lookup_addr
+           ~pc sec.addr thread
        in
        let breakpoints = [Z.of_int (sec.addr + Bytes.length sec.data)] in
        {Testrepr.regs; breakpoints}
@@ -368,13 +374,16 @@ let to_testrepr ~filename (ir : Ir.t) : Testrepr.t =
   let asm_input = to_assembly_input allocator ir in
   let asm_result = Assembler.assemble ~filename asm_input in
   let page_table = build_page_table_setup ir allocator asm_result in
+  let page_table_entries =
+    Option.map (fun layout -> layout.Page_table_builder.table_entries) page_table
+  in
   let lookup_addr = build_lookup_addr asm_result page_table in
   let page_table_root =
     Option.map (fun layout -> layout.Page_table_builder.root) page_table
   in
   let threads =
-    build_threads ~arch:ir.arch ?page_table_root ~lookup_addr asm_result
-      ir.threads
+    build_threads ~arch:ir.arch ?page_table_entries ?page_table_root ~lookup_addr
+      asm_result ir.threads
   in
   let memory =
     build_memory ~mem_size ~data_symbols:asm_input.symbols ~lookup_addr
@@ -387,6 +396,6 @@ let to_testrepr ~filename (ir : Ir.t) : Testrepr.t =
     kind = ir.kind;
     final =
       Assertion.map_cst
-        (eval_term ~context:Final_assertion ~lookup_addr)
+        (eval_term ?page_table_entries ~context:Final_assertion ~lookup_addr)
         ir.assertion
   }

--- a/cli/lib/isla/page_table/page_table_fns.ml
+++ b/cli/lib/isla/page_table/page_table_fns.ml
@@ -61,6 +61,65 @@ let descriptor_field_arg kwargs field_name default =
     value = Fn_registry.optional_kwarg field_name default kwargs
   }
 
+(** Find the page-table entry address for [va] at [level]. *)
+let pte_addr name entries ~base ~va ~level =
+  let rec walk table current_level =
+    let index = Page_table_desc.va_index va current_level in
+    let addr = table + (index * Page_table_desc.entry_size) in
+    if current_level = level then addr
+    else
+      let desc = List.assoc_opt addr entries |> Option.value ~default:0L in
+      match Page_table_desc.table_addr_of_descriptor desc with
+      | Some next_table -> walk next_table (current_level + 1)
+      | None ->
+          Fn_registry.error
+            "%s: No table descriptor at level %d for VA 0x%x, resolved to be at \
+             PA 0x%x in page-table rooted at 0x%x"
+             name current_level va addr base
+  in
+  walk base Page_table_desc.root_level
+
+(** [pteN(va, base)] treats [base] as the root translation-table PA, then
+    returns the identity-mapped VA of the matching PTE. *)
+let pte_function entries level =
+  let name = Printf.sprintf "pte%d" level in
+  ( name,
+    function
+    | [va; base] ->
+        let va = Fn_registry.int_arg name "va" va in
+        let base = Fn_registry.int_arg name "base" base in
+        let pte_pa = pte_addr name entries ~base ~va ~level in
+        let offset = pte_pa - base in
+        if offset < 0 || offset >= Allocator.big_size then
+          Fn_registry.error
+            "%s: PTE level %d for VA 0x%x was resolved at PA 0x%x which is \
+             outside page-table pool rooted at 0x%x"
+             name level va pte_pa base;
+        Z.of_int pte_pa
+    | args -> Fn_registry.arity_error name 2 (List.length args)
+  )
+
+(** [descN(va, base)] treats [base] as the root translation-table PA and
+    returns the descriptor stored in the matching level-[N] PTE. *)
+let desc_function entries level =
+  let name = Printf.sprintf "desc%d" level in
+  ( name,
+    function
+    | [va; base] -> (
+        let va = Fn_registry.int_arg name "va" va in
+        let base = Fn_registry.int_arg name "base" base in
+        let pte_pa = pte_addr name entries ~base ~va ~level in
+        match List.assoc_opt pte_pa entries with
+        | Some desc -> Z.of_int64 desc
+        | None ->
+            Fn_registry.error
+              "%s: Descriptor level %d for address 0x%x in page-table rooted at \
+               0x%x not found at resolved PA 0x%x"
+               name level va base pte_pa
+      )
+    | args -> Fn_registry.arity_error name 2 (List.length args)
+  )
+
 (** [mkdescN(oa=..., ...)] encodes a level-[N] block/page descriptor. *)
 let eval_desc name level kwargs =
   Fn_registry.check_kwargs name ["oa"; "Valid"; "AF"; "AP"; "DBM"] kwargs;
@@ -99,8 +158,15 @@ let mkdesc_function level =
   in
   (name, eval)
 
-let positional_functions : Fn_registry.positional_fn list =
-  [page_function; asid_function]
+let positional_functions ?page_table_entries () =
+  let functions = [page_function; asid_function] in
+  match page_table_entries with
+  | None -> functions
+  | Some page_table_entries ->
+      let levels = [0; 1; 2; 3] in
+      functions
+      @ List.map (pte_function page_table_entries) levels
+      @ List.map (desc_function page_table_entries) levels
 
 let keyword_functions : Fn_registry.keyword_fn list =
   let levels = [0; 1; 2; 3] in

--- a/cli/lib/isla/term.ml
+++ b/cli/lib/isla/term.ml
@@ -48,18 +48,19 @@ type t =
 
 let zero = Const Z.zero
 
-let positional_functions : Fn_registry.positional_fn list =
-  Bv_fns.functions @ Page_table_fns.positional_functions
-
-let keyword_functions : Fn_registry.keyword_fn list =
-  Page_table_fns.keyword_functions
-
-let rec eval ~lookup_addr = function
-  | Const z -> z
-  | Sym sym -> Z.of_int (lookup_addr sym)
-  | Fn (name, args) ->
-      let evaluated = List.map (eval ~lookup_addr) args in
-      Fn_registry.eval ~fns:positional_functions name evaluated
-  | KwFn (name, kwargs) ->
-      let evaluated = List.map (fun (k, v) -> (k, eval ~lookup_addr v)) kwargs in
-      Fn_registry.eval ~fns:keyword_functions name evaluated
+let eval ?page_table_entries ~lookup_addr term =
+  let positional_functions =
+    Bv_fns.functions @ Page_table_fns.positional_functions ?page_table_entries ()
+  in
+  let keyword_functions = Page_table_fns.keyword_functions in
+  let rec eval_term = function
+    | Const z -> z
+    | Sym sym -> Z.of_int (lookup_addr sym)
+    | Fn (name, args) ->
+        let evaluated = List.map eval_term args in
+        Fn_registry.eval ~fns:positional_functions name evaluated
+    | KwFn (name, kwargs) ->
+        let evaluated = List.map (fun (k, v) -> (k, eval_term v)) kwargs in
+        Fn_registry.eval ~fns:keyword_functions name evaluated
+  in
+  eval_term term


### PR DESCRIPTION
<!-- start jj-vine stack -->
This PR is part of a stack containing 3 PRs:

1. `feature/pgt-dsl-attribute`
2. #151
3. #154
4. **"feat(Isla): Add page table PTE functions" (this PR)**
<!-- end jj-vine stack -->

This PR supports
- `pteN(va, base)`, returning a VA that can be used as a memory operand for the matching PTE
- `descN(va, base)`, returning the descriptor value stored in the generated page table
