### PR TITLE
feat(Isla): Add levelled page-table mappings

### DIFF
--- a/cli/lib/isla/lexer.mll
+++ b/cli/lib/isla/lexer.mll
@@ -75,6 +75,9 @@ rule token = parse
   | "default" { DEFAULT }
   | "code" { CODE }
   | "data" { DATA }
+  | "table" { TABLE }
+  | "at" { AT }
+  | "level" { LEVEL }
   | "true" { TRUE }
   | "false" { FALSE }
   | '0' ['x' 'X'] hex+ as s { NUM (Z.of_string s) }

--- a/cli/lib/isla/page_table/page_table_ast.ml
+++ b/cli/lib/isla/page_table/page_table_ast.ml
@@ -54,6 +54,7 @@ type descriptor_field =
 type mapping_target =
   | PaName of string
   | Invalid
+  | Table of Z.t
 
 type stmt =
   (* [physical pa_x pa_y;] predeclares PA-side names. *)
@@ -63,13 +64,15 @@ type stmt =
   | Mapping of
       { va_name : string;
         target : mapping_target;
-        attrs : descriptor_field list
+        attrs : descriptor_field list;
+        level : int option
       }
   (* [x ?-> pa_x;] is accepted for Isla compatibility, but ignored entirely. *)
   | MaybeMapping of
       { va_name : string;
         target : mapping_target;
-        attrs : descriptor_field list
+        attrs : descriptor_field list;
+        level : int option
       }
   (* [*pa_x = value;] initialises data at a PA-side name. *)
   | DataInit of

--- a/cli/lib/isla/page_table/page_table_builder.ml
+++ b/cli/lib/isla/page_table/page_table_builder.ml
@@ -184,25 +184,39 @@ let add_code_mappings builder code_pages =
 
 (** {1 Statement evaluation} *)
 
-let eval_mapping_target ?(attrs = []) builder ~va = function
+let eval_mapping_target ?level ?(attrs = []) builder ~va = function
   | Page_table_ast.PaName pa_name ->
       let pa = alloc_pa builder pa_name in
-      add_mapping ~fields:attrs builder ~va ~pa Page_table_ast.Data
+      add_mapping ?level ~fields:attrs builder ~va ~pa Page_table_ast.Data
   | Page_table_ast.Invalid ->
       if attrs <> [] then
         error "page_table: descriptor fields are only supported on PA mappings";
-      write_descriptor builder ~va 0L
+      write_descriptor ?level builder ~va 0L
+  | Page_table_ast.Table addr ->
+      if attrs <> [] then
+        error "page_table: descriptor fields are only supported on PA mappings";
+      let level = Option.value ~default:Desc.last_level level in
+      let table_pa =
+        try Z.to_int addr
+        with Z.Overflow ->
+          error "page_table: table address out of range: %s" (Z.format "%#x" addr)
+      in
+      let desc =
+        try Desc.table_descriptor table_pa
+        with Failure msg -> error "page_table: %s" msg
+      in
+      write_descriptor ~level builder ~va desc
 
 let eval_stmt builder ~symbolic_vas = function
   | Page_table_ast.Physical names ->
       List.iter (fun name -> ignore (alloc_pa builder name)) names
-  | Page_table_ast.Mapping {va_name; target; attrs} ->
+  | Page_table_ast.Mapping {va_name; target; attrs; level} ->
       let va =
         match List.assoc_opt va_name symbolic_vas with
         | Some addr -> addr
         | None -> error "page_table: undeclared VA: %s" va_name
       in
-      eval_mapping_target ~attrs builder ~va target
+      eval_mapping_target ?level ~attrs builder ~va target
   | Page_table_ast.MaybeMapping _ -> ()
   | Page_table_ast.DataInit {pa_name; value} ->
       let pa = alloc_pa builder pa_name in

--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -66,6 +66,9 @@
 %token AND_KW
 %token CODE
 %token DATA
+%token TABLE
+%token AT
+%token LEVEL
 %token TRUE
 %token FALSE EOF
 
@@ -80,6 +83,8 @@
 %type <Page_table_ast.mapping_target> page_table_mapping_target
 %type <Page_table_ast.attr> page_table_attr
 %type <Page_table_ast.descriptor_field list> page_table_descriptor_attrs
+%type <int> page_table_mapping_level
+%type <string> kw_name
 
 %%
 
@@ -99,14 +104,16 @@ page_table_stmt_inner:
   | PHYSICAL; names = nonempty_list(IDENT)
     { Page_table_ast.Physical names }
   | va_name = IDENT; "|->"; target = page_table_mapping_target;
-    attrs = option(page_table_descriptor_attrs)
+    attrs = option(page_table_descriptor_attrs);
+    level = option(page_table_mapping_level)
     { Page_table_ast.Mapping
-        {va_name; target; attrs = Option.value ~default:[] attrs}
+        {va_name; target; attrs = Option.value ~default:[] attrs; level}
     }
   | va_name = IDENT; "?->"; target = page_table_mapping_target;
-    attrs = option(page_table_descriptor_attrs)
+    attrs = option(page_table_descriptor_attrs);
+    level = option(page_table_mapping_level)
     { Page_table_ast.MaybeMapping
-        {va_name; target; attrs = Option.value ~default:[] attrs}
+        {va_name; target; attrs = Option.value ~default:[] attrs; level}
     }
   | "*"; pa_name = IDENT; "="; value = NUM
     { Page_table_ast.DataInit {pa_name; value} }
@@ -118,6 +125,8 @@ page_table_mapping_target:
     { if name = "invalid" then Page_table_ast.Invalid
       else Page_table_ast.PaName name
     }
+  | TABLE; "("; addr = NUM; ")"
+    { Page_table_ast.Table addr }
 
 page_table_descriptor_attrs:
   | WITH; "[";
@@ -132,6 +141,12 @@ page_table_descriptor_attrs:
 page_table_attr:
   | CODE { Page_table_ast.Code }
   | DATA { Page_table_ast.Data }
+
+page_table_mapping_level:
+  | AT; LEVEL; level = NUM
+    { try Z.to_int level
+      with Z.Overflow -> failwith "page-table level is out of range"
+    }
 
 prop:
   | e1 = prop; "|"; e2 = prop { Or [e1; e2] }
@@ -158,4 +173,8 @@ term:
   | s = IDENT { Term.Sym s }
 
 kw_arg:
-  | k = IDENT; "="; v = term { (k, v) }
+  | k = kw_name; "="; v = term { (k, v) }
+
+kw_name:
+  | k = IDENT { k }
+  | TABLE { "table" }


### PR DESCRIPTION
- Add page-table setup syntax for explicit level mappings:
  - `x |-> invalid at level 2;`
  - `x |-> table(0x283000) at level 2;`
- Carry mapping targets and optional levels through the Isla page-table AST/parser.
- Write invalid/table descriptors into the requested page-table level using the shared descriptor-writing path.
