### PR TITLE
feat(Isla): Add invalid page-table mappings

### DIFF
--- a/cli/lib/isla/lexer.mll
+++ b/cli/lib/isla/lexer.mll
@@ -75,6 +75,7 @@ rule token = parse
   | "default" { DEFAULT }
   | "code" { CODE }
   | "data" { DATA }
+  | "invalid" { INVALID }
   | "true" { TRUE }
   | "false" { FALSE }
   | '0' ['x' 'X'] hex+ as s { NUM (Z.of_string s) }

--- a/cli/lib/isla/page_table/page_table_ast.ml
+++ b/cli/lib/isla/page_table/page_table_ast.ml
@@ -51,20 +51,24 @@ type descriptor_field =
     value : Z.t
   }
 
+type mapping_target =
+  | PaName of string
+  | Invalid
+
 type stmt =
   (* [physical pa_x pa_y;] predeclares PA-side names. *)
   | Physical of string list
-  (* [x |-> pa_x;] maps an existing symbolic VA to a PA-side name.
+  (* [x |-> pa_x;] maps an existing symbolic VA to a PA-side target.
      Optional [with ... and default] clauses override descriptor fields. *)
   | Mapping of
       { va_name : string;
-        pa_name : string;
+        target : mapping_target;
         attrs : descriptor_field list
       }
   (* [x ?-> pa_x;] is accepted for Isla compatibility, but ignored entirely. *)
   | MaybeMapping of
       { va_name : string;
-        pa_name : string;
+        target : mapping_target;
         attrs : descriptor_field list
       }
   (* [*pa_x = value;] initialises data at a PA-side name. *)

--- a/cli/lib/isla/page_table/page_table_builder.ml
+++ b/cli/lib/isla/page_table/page_table_builder.ml
@@ -152,14 +152,8 @@ let check_aligned_at_level name level addr =
     error "page_table: %s 0x%x is not aligned for a level %d mapping" name addr
       level
 
-(** Add the requested mapping, allocating intermediate tables on demand. *)
-let add_mapping ?(fields = []) ?(level = Desc.last_level) builder ~va ~pa kind =
-  let va = check_aligned_at_level "VA" level va in
-  let pa = check_aligned_at_level "PA" level pa in
-  let desc =
-    try Desc.make_descriptor ~fields ~level ~oa:pa ~kind ()
-    with Failure msg -> error "page_table: %s" msg
-  in
+(** Write an encoded descriptor at [va], allocating intermediate tables. *)
+let write_descriptor ?(level = Desc.last_level) builder ~va desc =
   let rec walk table current_level =
     let idx = Desc.va_index va current_level in
     if current_level = level then write_leaf table idx va desc
@@ -170,6 +164,16 @@ let add_mapping ?(fields = []) ?(level = Desc.last_level) builder ~va ~pa kind =
   let root_table = find_table builder.tables builder.root in
   walk root_table Desc.root_level
 
+(** Add the requested mapping, allocating intermediate tables on demand. *)
+let add_mapping ?(fields = []) ?(level = Desc.last_level) builder ~va ~pa kind =
+  let va = check_aligned_at_level "VA" level va in
+  let pa = check_aligned_at_level "PA" level pa in
+  let desc =
+    try Desc.make_descriptor ~fields ~level ~oa:pa ~kind ()
+    with Failure msg -> error "page_table: %s" msg
+  in
+  write_descriptor ~level builder ~va desc
+
 let add_code_mappings builder code_pages =
   List.iter
     (fun addr -> add_mapping builder ~va:addr ~pa:addr Page_table_ast.Code)
@@ -177,17 +181,25 @@ let add_code_mappings builder code_pages =
 
 (** {1 Statement evaluation} *)
 
+let eval_mapping_target ?(attrs = []) builder ~va = function
+  | Page_table_ast.PaName pa_name ->
+      let pa = alloc_pa builder pa_name in
+      add_mapping ~fields:attrs builder ~va ~pa Page_table_ast.Data
+  | Page_table_ast.Invalid ->
+      if attrs <> [] then
+        error "page_table: descriptor fields are only supported on PA mappings";
+      write_descriptor builder ~va 0L
+
 let eval_stmt builder ~symbolic_vas = function
   | Page_table_ast.Physical names ->
       List.iter (fun name -> ignore (alloc_pa builder name)) names
-  | Page_table_ast.Mapping {va_name; pa_name; attrs} ->
+  | Page_table_ast.Mapping {va_name; target; attrs} ->
       let va =
         match List.assoc_opt va_name symbolic_vas with
         | Some addr -> addr
         | None -> error "page_table: undeclared VA: %s" va_name
       in
-      let pa = alloc_pa builder pa_name in
-      add_mapping ~fields:attrs builder ~va ~pa Page_table_ast.Data
+      eval_mapping_target ~attrs builder ~va target
   | Page_table_ast.MaybeMapping _ -> ()
   | Page_table_ast.DataInit {pa_name; value} ->
       let pa = alloc_pa builder pa_name in

--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -66,6 +66,7 @@
 %token AND_KW
 %token CODE
 %token DATA
+%token INVALID
 %token TRUE
 %token FALSE EOF
 
@@ -77,6 +78,7 @@
 %start <Term.t> binding
 %start <Page_table_ast.stmt list> page_table_setup
 %type <Page_table_ast.stmt> page_table_stmt page_table_stmt_inner
+%type <Page_table_ast.mapping_target> page_table_mapping_target
 %type <Page_table_ast.attr> page_table_attr
 %type <Page_table_ast.descriptor_field list> page_table_descriptor_attrs
 
@@ -97,20 +99,24 @@ page_table_stmt:
 page_table_stmt_inner:
   | PHYSICAL; names = nonempty_list(IDENT)
     { Page_table_ast.Physical names }
-  | va_name = IDENT; "|->"; pa_name = IDENT;
+  | va_name = IDENT; "|->"; target = page_table_mapping_target;
     attrs = option(page_table_descriptor_attrs)
     { Page_table_ast.Mapping
-        {va_name; pa_name; attrs = Option.value ~default:[] attrs}
+        {va_name; target; attrs = Option.value ~default:[] attrs}
     }
-  | va_name = IDENT; "?->"; pa_name = IDENT;
+  | va_name = IDENT; "?->"; target = page_table_mapping_target;
     attrs = option(page_table_descriptor_attrs)
     { Page_table_ast.MaybeMapping
-        {va_name; pa_name; attrs = Option.value ~default:[] attrs}
+        {va_name; target; attrs = Option.value ~default:[] attrs}
     }
   | "*"; pa_name = IDENT; "="; value = NUM
     { Page_table_ast.DataInit {pa_name; value} }
   | IDENTITY; addr = NUM; WITH; attr = page_table_attr
     { Page_table_ast.IdentityMapping {addr; attr} }
+
+page_table_mapping_target:
+  | name = IDENT { Page_table_ast.PaName name }
+  | INVALID { Page_table_ast.Invalid }
 
 page_table_descriptor_attrs:
   | WITH; "[";


### PR DESCRIPTION
- Supports `x |-> invalid;`.
- Currently, it supports invalidation at level 3. Subsequent PR will support different level mappings.