### PR TITLE
feat(Isla): Add levelled page-table mappings

### DIFF
--- a/cli/lib/isla/lexer.mll
+++ b/cli/lib/isla/lexer.mll
@@ -76,6 +76,9 @@ rule token = parse
   | "code" { CODE }
   | "data" { DATA }
   | "invalid" { INVALID }
+  | "table" { TABLE }
+  | "at" { AT }
+  | "level" { LEVEL }
   | "true" { TRUE }
   | "false" { FALSE }
   | '0' ['x' 'X'] hex+ as s { NUM (Z.of_string s) }

--- a/cli/lib/isla/page_table/page_table_ast.ml
+++ b/cli/lib/isla/page_table/page_table_ast.ml
@@ -54,6 +54,7 @@ type descriptor_field =
 type mapping_target =
   | PaName of string
   | Invalid
+  | Table of Z.t
 
 type stmt =
   (* [physical pa_x pa_y;] predeclares PA-side names. *)
@@ -63,13 +64,15 @@ type stmt =
   | Mapping of
       { va_name : string;
         target : mapping_target;
-        attrs : descriptor_field list
+        attrs : descriptor_field list;
+        level : int option
       }
   (* [x ?-> pa_x;] is accepted for Isla compatibility, but ignored entirely. *)
   | MaybeMapping of
       { va_name : string;
         target : mapping_target;
-        attrs : descriptor_field list
+        attrs : descriptor_field list;
+        level : int option
       }
   (* [*pa_x = value;] initialises data at a PA-side name. *)
   | DataInit of

--- a/cli/lib/isla/page_table/page_table_builder.ml
+++ b/cli/lib/isla/page_table/page_table_builder.ml
@@ -181,25 +181,46 @@ let add_code_mappings builder code_pages =
 
 (** {1 Statement evaluation} *)
 
-let eval_mapping_target ?(attrs = []) builder ~va = function
+let check_table_level = function
+  | None -> error "page_table: table descriptors require an explicit level"
+  | Some level when level < Desc.root_level || level >= Desc.last_level ->
+      error "page_table: table descriptors are only valid at levels %d..%d"
+        Desc.root_level (Desc.last_level - 1)
+  | Some level -> level
+
+let eval_mapping_target ?level ?(attrs = []) builder ~va = function
   | Page_table_ast.PaName pa_name ->
       let pa = alloc_pa builder pa_name in
-      add_mapping ~fields:attrs builder ~va ~pa Page_table_ast.Data
+      add_mapping ?level ~fields:attrs builder ~va ~pa Page_table_ast.Data
   | Page_table_ast.Invalid ->
       if attrs <> [] then
         error "page_table: descriptor fields are only supported on PA mappings";
-      write_descriptor builder ~va 0L
+      write_descriptor ?level builder ~va 0L
+  | Page_table_ast.Table addr ->
+      if attrs <> [] then
+        error "page_table: descriptor fields are only supported on PA mappings";
+      let level = check_table_level level in
+      let table_pa =
+        try Z.to_int addr
+        with Z.Overflow ->
+          error "page_table: table address out of range: %s" (Z.format "%#x" addr)
+      in
+      let desc =
+        try Desc.table_descriptor table_pa
+        with Failure msg -> error "page_table: %s" msg
+      in
+      write_descriptor ~level builder ~va desc
 
 let eval_stmt builder ~symbolic_vas = function
   | Page_table_ast.Physical names ->
       List.iter (fun name -> ignore (alloc_pa builder name)) names
-  | Page_table_ast.Mapping {va_name; target; attrs} ->
+  | Page_table_ast.Mapping {va_name; target; attrs; level} ->
       let va =
         match List.assoc_opt va_name symbolic_vas with
         | Some addr -> addr
         | None -> error "page_table: undeclared VA: %s" va_name
       in
-      eval_mapping_target ~attrs builder ~va target
+      eval_mapping_target ?level ~attrs builder ~va target
   | Page_table_ast.MaybeMapping _ -> ()
   | Page_table_ast.DataInit {pa_name; value} ->
       let pa = alloc_pa builder pa_name in

--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -67,6 +67,9 @@
 %token CODE
 %token DATA
 %token INVALID
+%token TABLE
+%token AT
+%token LEVEL
 %token TRUE
 %token FALSE EOF
 
@@ -78,9 +81,13 @@
 %start <Term.t> binding
 %start <Page_table_ast.stmt list> page_table_setup
 %type <Page_table_ast.stmt> page_table_stmt page_table_stmt_inner
+%type <Page_table_ast.mapping_target * Page_table_ast.descriptor_field list * int option>
+  page_table_mapping_rhs
 %type <Page_table_ast.mapping_target> page_table_mapping_target
 %type <Page_table_ast.attr> page_table_attr
 %type <Page_table_ast.descriptor_field list> page_table_descriptor_attrs
+%type <int> page_table_mapping_level
+%type <string> kw_name
 
 %%
 
@@ -99,20 +106,26 @@ page_table_stmt:
 page_table_stmt_inner:
   | PHYSICAL; names = nonempty_list(IDENT)
     { Page_table_ast.Physical names }
-  | va_name = IDENT; "|->"; target = page_table_mapping_target;
-    attrs = option(page_table_descriptor_attrs)
-    { Page_table_ast.Mapping
-        {va_name; target; attrs = Option.value ~default:[] attrs}
+  | va_name = IDENT; "|->"; rhs = page_table_mapping_rhs
+    { let (target, attrs, level) = rhs in
+      Page_table_ast.Mapping {va_name; target; attrs; level}
     }
-  | va_name = IDENT; "?->"; target = page_table_mapping_target;
-    attrs = option(page_table_descriptor_attrs)
-    { Page_table_ast.MaybeMapping
-        {va_name; target; attrs = Option.value ~default:[] attrs}
+  | va_name = IDENT; "?->"; rhs = page_table_mapping_rhs
+    { let (target, attrs, level) = rhs in
+      Page_table_ast.MaybeMapping {va_name; target; attrs; level}
     }
   | "*"; pa_name = IDENT; "="; value = NUM
     { Page_table_ast.DataInit {pa_name; value} }
   | IDENTITY; addr = NUM; WITH; attr = page_table_attr
     { Page_table_ast.IdentityMapping {addr; attr} }
+
+page_table_mapping_rhs:
+  | target = page_table_mapping_target;
+    attrs = option(page_table_descriptor_attrs);
+    level = option(page_table_mapping_level)
+    { (target, Option.value ~default:[] attrs, level) }
+  | TABLE; "("; addr = NUM; ")"; level = page_table_mapping_level
+    { (Page_table_ast.Table addr, [], Some level) }
 
 page_table_mapping_target:
   | name = IDENT { Page_table_ast.PaName name }
@@ -131,6 +144,12 @@ page_table_descriptor_attrs:
 page_table_attr:
   | CODE { Page_table_ast.Code }
   | DATA { Page_table_ast.Data }
+
+page_table_mapping_level:
+  | AT; LEVEL; level = NUM
+    { try Z.to_int level
+      with Z.Overflow -> failwith "page-table level is out of range"
+    }
 
 prop:
   | e1 = prop; "|"; e2 = prop { Or [e1; e2] }
@@ -157,4 +176,8 @@ term:
   | s = IDENT { Term.Sym s }
 
 kw_arg:
-  | k = IDENT; "="; v = term { (k, v) }
+  | k = kw_name; "="; v = term { (k, v) }
+
+kw_name:
+  | k = IDENT { k }
+  | TABLE { "table" }


### PR DESCRIPTION
- Add page-table setup syntax for explicit level mappings:
  - `x |-> invalid at level 2;`
  - `x |-> table(0x283000) at level 2;`
- Carry mapping targets and optional levels through the Isla page-table AST/parser.
- Write invalid/table descriptors into the requested page-table level using the shared descriptor-writing path.
