### PR TITLE
feat(VMPromising): Restrict TLBI promise suffix ordering

### DIFF
--- a/ArchSem/GenPromising.v
+++ b/ArchSem/GenPromising.v
@@ -183,6 +183,10 @@ Module GenPromising (Arch : Arch) (Inter : InterfaceT Arch)
       mEvent_eq_dec : EqDecision mEvent;
       (** Give the tid that initiated that event *)
       mEvent_tid : mEvent → nat;
+      (** Filter executable promise candidates from a single enumeration run.
+          The memory does not yet contain the candidates being selected. *)
+      filter_promises : (* num of threads *) nat → (* tid *) nat →
+                        PromMemory.t mEvent → list mEvent → list mEvent;
       (** The address space this model is built against, we expect non-secure
           for Arm here *)
       address_space : addr_space;
@@ -454,6 +458,7 @@ Module GenPromising (Arch : Arch) (Inter : InterfaceT Arch)
         let promises :=
           List.concat ((success_states.*1) ++ (Exec.errors res).*1.*1)
             |> remove_dups in
+        let promises := prom.(filter_promises) n tid mem promises in
         let tstates :=
           success_states
           |> omap (λ '(new_proms, st),

--- a/ArchSemArm/UMPromising.v
+++ b/ArchSemArm/UMPromising.v
@@ -578,6 +578,7 @@ Definition UMPromising : Promising.Model :=
     address_space := PAS_NonSecure;
     mEvent := Msg.t;
     mEvent_tid := Msg.tid;
+    filter_promises := λ _ _ _ promises, promises;
     handle_outcome := λ _ tid initmem, run_outcome tid initmem;
     emit_promise := λ tid initmem mem msg, TState.promise (length mem);
     check_valid_end := λ _ _ _ _, [];

--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -150,6 +150,12 @@ Module Ev.
     | _ => None
     end.
 
+  Definition get_tlbi_recipient (ev : t) : option nat :=
+    match ev with
+    | Tlbi _ recipient => Some recipient
+    | _ => None
+    end.
+
   (** Checks whether an write event overlaps an address range *)
   Definition addr_overlap (a : address) (sz : N) (ev : t) : Prop :=
     match ev with
@@ -2614,6 +2620,24 @@ Definition emit_promise' (tid : nat) (initmem : memoryMap) (mem : Memory.t) ev :
   if ev is Ev.Msg _ then TState.promise_write (length mem)
   else TState.promise_tlbi (length mem).
 
+(** Avoid exploring duplicate TLBI promise orders.  During one enumeration run,
+    we keep TLBI recipients in nondecreasing order, comparing each candidate
+    with the last TLBI promise already selected in memory. *)
+Definition filter_tlbi_promises
+    (n_threads tid : nat) (mem : Memory.t) (candidates : list Ev.t) :
+    list Ev.t :=
+  let run_recipient :=
+    if mem is ev :: _ then Ev.get_tlbi_recipient ev else None in
+  filter (λ ev,
+    match Ev.get_tlbi_recipient ev with
+    | Some recipient =>
+      match run_recipient with
+      | Some prev_recipient => prev_recipient <=? recipient
+      | None => true
+      end
+    | None => true
+    end) candidates.
+
 Definition VMPromising (bbm_param : BBM.param) : Promising.Model :=
   {|tState := TState.t;
     tState_init := λ tid, TState.init;
@@ -2624,6 +2648,7 @@ Definition VMPromising (bbm_param : BBM.param) : Promising.Model :=
     address_space := PAS_NonSecure;
     mEvent := Ev.t;
     mEvent_tid := Ev.tid;
+    filter_promises := filter_tlbi_promises;
     handle_outcome := run_outcome;
     emit_promise := emit_promise';
     check_valid_end := λ tid initmem ts mem, BBM.check bbm_param tid initmem ts mem;


### PR DESCRIPTION
`Artem3+TLBIVMALL+dmb.sy+dmb.ld.litmus.toml` admits the non-atomicity witness, but this PR makes less case runs compared to the base branch:

```text
base:
Observation Artem3+TLBIVMALL+dmb.sy+dmb.ld Sometimes 64 17792
Time 87.341

current:
Observation Artem3+TLBIVMALL+dmb.sy+dmb.ld Sometimes 32 4796
Time 36.540
```