### PR TITLE
fix(Isla): Parse label-valued terms

### DIFF
--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -173,6 +173,7 @@ term:
   | v = NUM { Term.Const v }
   | "-"; v = NUM { Term.Const (Z.neg v) }
   | fn = fn_term { fn }
+  | s = IDENT; ":" { Term.Sym s }
   | s = IDENT { Term.Sym s }
 
 fn_term:


### PR DESCRIPTION
- Accept label-valued IDENT ":" expressions in the Isla term parser.