### PR TITLE
fix(VMPromising): Handle ETS2 invalid PTE faults

### DIFF
--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -1678,11 +1678,11 @@ Module TLB.
                 (ts : TState.t)
                 (init : memoryMap)
                 (mem : Memory.t)
-                (tid : nat) (is_ets2 : bool)
+                (tid : nat) (is_ets2_or_later : bool)
                 (va : bv 64) (asid : bv 16) (ttbr : reg) :
               result string (list (bv 64 * list (bv 64) * nat * option nat)) :=
     foldrM (λ '(tlb, trans_time) entries,
-      if decide (is_ets2 ∧ trans_time < ts.(TState.vwr) ⊔ ts.(TState.vrd)) then
+      if decide (is_ets2_or_later ∧ trans_time < ts.(TState.vwr) ⊔ ts.(TState.vrd)) then
         mret entries
       else
         candidates ← TLB.get_invalid_ptes_with_inv_time ts init mem tid tlb trans_time va asid ttbr;
@@ -2219,7 +2219,7 @@ Definition ttbr_of_regime (va : bv 64) (regime : Regime) : result string reg :=
   | _ => Error "This model does not support multiple regimes"
   end.
 
-Definition ets2 (ts : TState.t) : result string bool :=
+Definition ets2_or_later (ts : TState.t) : result string bool :=
   '(mmfr1, _) ← othrow
     "ETS is indicated in the ID_AA64MMFR1_EL1 register value"
     (TState.read_reg ts ID_AA64MMFR1_EL1);
@@ -2259,9 +2259,9 @@ Definition run_trans_start (trans_start : TranslationStartInfo)
   let is_ifetch :=
     trans_start.(TranslationStartInfo_accdesc).(AccessDescriptor_acctype) =?
     AccessType_IFETCH in
-  is_ets2 ← mlift (ets2 ts);
+  is_ets2_or_later ← mlift (ets2_or_later ts);
   let vpre_t := ts.(TState.vcse) ⊔
-                 (view_if (is_ets2 && (negb is_ifetch)) ts.(TState.vdsb)) in
+                 (view_if (is_ets2_or_later && (negb is_ifetch)) ts.(TState.vdsb)) in
   let vmax_t := length mem in
   (* lookup (successful results or faults) *)
   let asid := trans_start.(TranslationStartInfo_asid) in
@@ -2274,9 +2274,12 @@ Definition run_trans_start (trans_start : TranslationStartInfo)
       let snapshots := TLB.snapshots_from vpre_t snapshots in
       valid_entries ← mlift $
         TLB.get_valid_entries_from_snapshots snapshots mem tid va asid;
+      let invalid_vpre_t :=
+        vpre_t ⊔ view_if is_ets2_or_later (ts.(TState.vwr) ⊔ ts.(TState.vrd)) in
+      let invalid_snapshots := TLB.snapshots_from invalid_vpre_t snapshots in
       invalid_entries ← mlift $
         TLB.get_invalid_entries_from_snapshots
-          snapshots ts init mem tid is_ets2 va asid ttbr;
+          invalid_snapshots ts init mem tid is_ets2_or_later va asid ttbr;
       (* update IIS with either a valid translation result or an invalid result *)
       valid_res ←
         for (val_ttbr, path, t, ti) in valid_entries do


### PR DESCRIPTION
Fixes an ETS2 invalid-PTE case. The motivating test is `R+rel+lws-mmufault-po`, which expects `Forbidden` in the VMSA-ETS2 kind, while the old ArchSem behavior could produce `no-behaviour`.

```text
Initial page table:
  z |-> pa_z with [Valid = 0b0]   // z is invalid from the start

P1:
  STR y = 2                       // advances the write view
  STR z = 0                       // should read the invalid PTE and take a translation fault

P1 EL1 handler:
  LDR x                           // runs after the fault

Forbidden final condition:
  *pa_y = 2 /\ 1:X2 = 0
```

Before this patch, the invalid `z` fault candidate was only seen from the initial snapshot (`trans_time = 0`). After `STR y = 2` advanced the write view, ETS2 rejected that stale `0 < vwr` candidate, leaving no invalid translation candidate for `STR z`.

This patch:

- collects ETS2 invalid fault candidates from snapshots after the prior read/write view;
- preserves the existing valid-PTE translation behavior. AF=0 final descriptor handling is left for a separate fix.

Ref: Arm ARM DDI0487M.c B2.3 treats Translation Fault Effects as `TLBUncacheable`, and `FEAT_ETS2` orders the implicit TTD read before such a fault, so the invalid PTE read must be selected from a sufficiently late snapshot.
