### PR TITLE
fix(VMPromising): Enforce VA translation coherence

### DIFF
--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -445,6 +445,8 @@ Module TState.
 
         (* Per-byte coherence views *)
         coh : gmap address view;
+        (* Per-ASID/page-offset translation coherence views. *)
+        tcoh : gmap (bv 16 * bv 12)%type view;
 
         vrd : view; (* The maximum output view of a read  *)
         vwr : view; (* The maximum output view of a write  *)
@@ -467,7 +469,7 @@ Module TState.
       }.
 
   #[global] Instance eta : Settable _ :=
-    settable! make <prom_wr; prom_tlbi;regs;levs;coh;vrd;vwr;vdmbst;vdmb;vdsb;
+    settable! make <prom_wr; prom_tlbi;regs;levs;coh;tcoh;vrd;vwr;vdmbst;vdmb;vdsb;
                     vspec;vcse;vtlbi_self;vtlbi_other;vmsr;vacq;vrel;fwdb;xclb>.
 
   (* TODO Check and remove mem as an argument here *)
@@ -478,6 +480,7 @@ Module TState.
       regs := dmap_map (λ _ v, (v, 0%nat)) iregs;
       levs := []; (* latest event at the top of the list *)
       coh := ∅;
+      tcoh := ∅;
       vrd := 0;
       vwr := 0;
       vdmbst := 0;
@@ -602,6 +605,30 @@ Module TState.
   (** Max coherence view across a range of byte addresses *)
   Definition max_cohs (addrs : list address) (ts : t) : view :=
     foldr max 0%nat (map (λ a, ts.(coh) !!! a) addrs).
+
+  Definition va_page_offsets (va : bv 64) (size : N) : list (bv 12) :=
+    map (λ n, bv_extract 0 12 (va `+Z` (Z.of_N n))%bv) (seqN 0 size).
+
+  Definition get_tcoh (asid : bv 16) (page_offset : bv 12) (ts : t) : view :=
+    ts.(tcoh) !!! (asid, page_offset).
+
+  Definition update_tcoh (asid : bv 16) (page_offset : bv 12) (v : view) (ts : t) : t :=
+    set tcoh
+      (partial_alter (λ ov, Some (max v (default 0 ov)))
+        (asid, page_offset)) ts.
+
+  Definition update_tcohs (asid : bv 16) (page_offsets : list (bv 12)) (v : view) (ts : t) : t :=
+    foldr (λ page_offset, update_tcoh asid page_offset v) ts page_offsets.
+
+  Definition tcohs_before_inv_time (asid : bv 16) (page_offsets : list (bv 12))
+      (inv_time : option nat) (ts : t) : Prop :=
+    match inv_time with
+    | Some inv_t => ∀ page_offset ∈ page_offsets, (get_tcoh asid page_offset ts < inv_t)%nat
+    | None => True
+    end.
+  #[global] Instance Decision_tcohs_before_inv_time asid page_offsets inv_time ts :
+    Decision (tcohs_before_inv_time asid page_offsets inv_time ts).
+  Proof. unfold_decide. Defined.
 
   (** Sets the forwarding database for an address *)
   Definition set_fwdb (addr : address) (fi : FwdItem.t) : t → t :=
@@ -2342,6 +2369,7 @@ Definition run_trans_start (trans_start : TranslationStartInfo)
   (* lookup (successful results or faults) *)
   let asid := trans_start.(TranslationStartInfo_asid) in
   let va : bv 64 := trans_start.(TranslationStartInfo_va) in
+  let size := Z.to_N trans_start.(TranslationStartInfo_size) in
 
   trans_res ←
     if decide (va_in_range va) then
@@ -2394,8 +2422,13 @@ Definition run_trans_start (trans_start : TranslationStartInfo)
       mchoosel (valid_res ++ invalid_res)
     else
       mret $ (IIS.TransRes.make (va_to_vpn va) vpre_t vmax_t None [], None);
-  mset PPState.iis $ IIS.set_trs trans_res.1;;
-  mset PPState.iis $ IIS.set_inv_time trans_res.2.
+  let '(tres, inv_time) := trans_res in
+  let page_offsets := TState.va_page_offsets va size in
+  guard_discard (TState.tcohs_before_inv_time asid page_offsets inv_time ts);;
+  mset PPState.state $
+    TState.update_tcohs asid page_offsets tres.(IIS.TransRes.trans_start);;
+  mset PPState.iis $ IIS.set_trs tres;;
+  mset PPState.iis $ IIS.set_inv_time inv_time.
 
 (** Compute the pre-view for a translation fault on a read access. *)
 Definition read_fault_vpre (is_acq : bool)


### PR DESCRIPTION
- Track per-ASID low-order VA translation coherence views.
- Reject translations that would pass a later invalidating TLBI.
- Update the translation coherence view when a walk result is selected.