### PR TITLE
feat(Isla): Support named page-table roots

### DIFF
--- a/cli/lib/isla/converter.ml
+++ b/cli/lib/isla/converter.ml
@@ -310,10 +310,15 @@ let build_page_table_setup ir allocator asm_result =
            )
           ir.Ir.threads
       in
+      let reserved_pages =
+        List.map
+          (fun (section : Assembler.linked_section) -> section.addr)
+          asm_result.Assembler.sections
+      in
       try
         Some
           (Page_table_builder.build ~arch:ir.arch ~allocator ~symbolic_vas
-             ~code_pages page_table_setup
+             ~code_pages ~reserved_pages page_table_setup
           )
       with Page_table_builder.Error msg -> eval_error Page_table_setup "%s" msg
     )
@@ -324,7 +329,11 @@ let build_lookup_addr asm_result page_table =
   let page_table_symbols =
     match page_table with
     | None -> []
-    | Some layout -> layout.Page_table_builder.symbols_pa
+    | Some layout ->
+        ("page_table_base", layout.Page_table_builder.root)
+        :: (layout.Page_table_builder.table_symbols_pa
+          @ layout.Page_table_builder.data_symbols_pa
+           )
   in
   let symbols_addr = asm_result.Assembler.symbols @ page_table_symbols in
   fun name ->
@@ -412,7 +421,7 @@ let build_page_table_memory ~default_mem_size ~symbol_sizes page_table =
          in
          data_memory_block ~step:mem_size ~symbol:sym pa value
        )
-      page_table.Page_table_builder.phys_symbols_pa
+      page_table.Page_table_builder.data_symbols_pa
   in
   table_memory @ phys_memory
 

--- a/cli/lib/isla/lexer.mll
+++ b/cli/lib/isla/lexer.mll
@@ -66,6 +66,8 @@ rule token = parse
   | ';' { SEMICOLON }
   | '[' { LBRACKET }
   | ']' { RBRACKET }
+  | '{' { LBRACE }
+  | '}' { RBRACE }
   | ',' { COMMA }
   | '-' { MINUS }
   | "aligned" { ALIGNED }
@@ -79,6 +81,8 @@ rule token = parse
   | "data" { DATA }
   | "invalid" { INVALID }
   | "table" { TABLE }
+  | "s1table" { S1TABLE }
+  | "s2table" { S2TABLE }
   | "at" { AT }
   | "level" { LEVEL }
   | "true" { TRUE }

--- a/cli/lib/isla/page_table/page_table_ast.ml
+++ b/cli/lib/isla/page_table/page_table_ast.ml
@@ -48,6 +48,11 @@ type attr =
   | Code
   | Data
 
+type table_stage =
+  | S1
+  | S2
+  (** TODO: Implement stage-2-specific descriptor encoding and validation. *)
+
 type descriptor_field =
   { name : string;
     value : Z.t
@@ -92,4 +97,10 @@ type stmt =
   | IdentityMapping of
       { addr : Z.t;
         attr : attr
+      }
+  | TableBlock of
+      { stage : table_stage;
+        name : string;
+        base : Z.t;
+        body : stmt list
       }

--- a/cli/lib/isla/page_table/page_table_builder.ml
+++ b/cli/lib/isla/page_table/page_table_builder.ml
@@ -53,8 +53,8 @@ type data_value = Z.t
 type layout =
   { root : pa;
     table_entries : (pa * descriptor) list;
-    symbols_pa : (string * pa) list;
-    phys_symbols_pa : (string * pa) list;
+    table_symbols_pa : (string * pa) list;
+    data_symbols_pa : (string * pa) list;
     data_inits : (pa * data_value) list
   }
 
@@ -62,32 +62,60 @@ exception Error of string
 
 let error fmt = Printf.ksprintf (fun msg -> raise (Error msg)) fmt
 
+type table_root =
+  { stage : Page_table_ast.table_stage;
+    name : string option;
+    base : pa;
+    mutable next_table_pa : pa
+  }
+
+let page_base addr = addr - (addr mod Allocator.page_size)
+
+let same_page addr1 addr2 = page_base addr1 = page_base addr2
+
 type t =
   { allocator : Allocator.t;
-    (* Root translation-table address. *)
-    root : pa;
-    (* Next free page in the translation-table pool. *)
-    mutable next_table_pa : pa;
+    (* Implicit S1 root allocated from the global address allocator. *)
+    default_root : table_root;
+    (* Roots declared explicitly by named table blocks. *)
+    mutable named_roots : table_root list;
+    (* 4KB pages actually occupied by roots and descendant tables. *)
+    mutable table_pages : pa list;
+    (* Pre-existing code pages unavailable to table and data allocation. *)
+    reserved_pages : pa list;
     (* Page-table descriptors, keyed by their physical addresses. *)
     entries : (pa, descriptor) Hashtbl.t;
     (* PA names declared by [physical]. *)
     mutable declared_pas : string list;
     (* PA names and their allocated physical addresses. *)
-    mutable symbols_pa : (string * pa) list;
+    mutable data_symbols_pa : (string * pa) list;
     (* Initial data values, keyed by their allocated PAs. *)
     mutable data_inits : (pa * data_value) list
   }
 
-let make allocator ~root =
-  let entries = Hashtbl.create 256 in
+let make allocator ~root ~reserved_pages =
+  let default_root =
+    { stage = Page_table_ast.S1;
+      name = None;
+      base = root;
+      next_table_pa = root + Allocator.page_size
+    }
+  in
   { allocator;
-    entries;
-    root;
-    next_table_pa = root + Allocator.page_size;
+    default_root;
+    named_roots = [];
+    table_pages = [root];
+    reserved_pages = List.map page_base reserved_pages;
+    entries = Hashtbl.create 256;
     declared_pas = [];
-    symbols_pa = [];
+    data_symbols_pa = [];
     data_inits = []
   }
+
+let page_is_occupied builder addr =
+  List.exists (same_page addr) builder.reserved_pages
+  || List.exists (same_page addr) builder.table_pages
+  || List.exists (fun (_, pa) -> same_page addr pa) builder.data_symbols_pa
 
 let check_arch = function
   | Litmus.Arch_id.Arm -> ()
@@ -95,10 +123,10 @@ let check_arch = function
       error "page_table: only AArch64 is supported, got %s"
         (Litmus.Arch_id.to_string arch)
 
-let alloc_pa ?(alignment = Allocator.page_size) ?mapping_level builder name =
+let alloc_physical ?(alignment = Allocator.page_size) ?mapping_level builder name =
   if not (List.mem name builder.declared_pas) then
     error "page_table: undeclared PA: %s" name;
-  match List.assoc_opt name builder.symbols_pa with
+  match List.assoc_opt name builder.data_symbols_pa with
   | Some addr -> (
       if addr mod alignment = 0 then addr
       else
@@ -113,21 +141,83 @@ let alloc_pa ?(alignment = Allocator.page_size) ?mapping_level builder name =
               name addr alignment
     )
   | None ->
-      let addr =
-        Allocator.alloc_aligned builder.allocator ~size:Allocator.page_size
-          ~alignment
+      let rec alloc () =
+        let addr =
+          Allocator.alloc_aligned builder.allocator ~size:Allocator.page_size
+            ~alignment
+        in
+        if page_is_occupied builder addr then alloc () else addr
       in
-      builder.symbols_pa <- (name, addr) :: builder.symbols_pa;
+      let addr = alloc () in
+      builder.data_symbols_pa <- (name, addr) :: builder.data_symbols_pa;
       addr
 
 (** {1 Table page allocation} *)
 
-(** Allocate a fresh table page. *)
-let create_table_page builder =
-  if builder.next_table_pa >= builder.root + Allocator.big_size then
-    error "page_table: 2MB page-table pool exhausted";
-  let addr = builder.next_table_pa in
-  builder.next_table_pa <- addr + Allocator.page_size;
+let addr_of_z name addr =
+  try Z.to_int addr
+  with Z.Overflow ->
+    error "page_table: %s out of range: %s" name (Z.format "%#x" addr)
+
+let find_root builder ~stage ~name =
+  match
+    List.find_opt
+      (fun root -> root.stage = stage && root.name = Some name)
+      builder.named_roots
+  with
+  | Some root -> root
+  | None -> error "page_table: unknown table root: %s" name
+
+let reserve_root builder ~reserved_names ~stage ~name ~base =
+  let base = addr_of_z "table base" base in
+  if base mod Allocator.page_size <> 0 then
+    error "page_table: table base 0x%x is not page aligned" base;
+  if List.mem name reserved_names then
+    error "page_table: table root name conflicts with existing symbol: %s" name;
+  if List.exists (fun root -> root.name = Some name) builder.named_roots then
+    error "page_table: duplicate table root: %s" name;
+  ( match List.find_opt (same_page base) builder.reserved_pages with
+  | Some addr ->
+      error "page_table: table base 0x%x overlaps existing memory page at 0x%x"
+        base addr
+  | None -> ()
+  );
+  if
+    builder.default_root.base = base
+    || List.exists (fun root -> root.base = base) builder.named_roots
+  then error "page_table: duplicate table base: 0x%x" base;
+  let root =
+    {stage; name = Some name; base; next_table_pa = base + Allocator.page_size}
+  in
+  builder.named_roots <- root :: builder.named_roots;
+  builder.table_pages <- base :: builder.table_pages
+
+let rec reserve_table_roots builder ~reserved_names = function
+  | [] -> ()
+  | Page_table_ast.TableBlock {stage; name; base; body} :: stmts ->
+      reserve_root builder ~reserved_names ~stage ~name ~base;
+      reserve_table_roots builder ~reserved_names body;
+      reserve_table_roots builder ~reserved_names stmts
+  | _ :: stmts -> reserve_table_roots builder ~reserved_names stmts
+
+let rec declared_pa_names = function
+  | [] -> []
+  | Page_table_ast.Physical names :: stmts -> names @ declared_pa_names stmts
+  | Page_table_ast.TableBlock {body; _} :: stmts ->
+      declared_pa_names body @ declared_pa_names stmts
+  | _ :: stmts -> declared_pa_names stmts
+
+(** Allocate a fresh table page in [root]'s 2MB table pool. *)
+let create_table_page builder root =
+  let rec find_free addr =
+    if addr >= root.base + Allocator.big_size then
+      error "page_table: 2MB page-table pool exhausted";
+    if page_is_occupied builder addr then find_free (addr + Allocator.page_size)
+    else addr
+  in
+  let addr = find_free root.next_table_pa in
+  root.next_table_pa <- addr + Allocator.page_size;
+  builder.table_pages <- addr :: builder.table_pages;
   addr
 
 let entry_addr table_addr idx = table_addr + (idx * Desc.entry_size)
@@ -146,8 +236,8 @@ let write_entry builder table_addr idx desc =
   );
   Hashtbl.replace builder.entries slot_addr desc
 
-let create_child_table builder parent_addr idx =
-  let child_addr = create_table_page builder in
+let create_child_table builder root parent_addr idx =
+  let child_addr = create_table_page builder root in
   try
     write_entry builder parent_addr idx (Desc.table_descriptor child_addr);
     child_addr
@@ -163,10 +253,10 @@ let child_table_addr builder table_addr idx =
 (** {1 Mapping path construction} *)
 
 (** Reuse an existing child table descriptor, or install a new child table. *)
-let ensure_child_table builder parent_addr idx =
+let ensure_child_table builder root parent_addr idx =
   match child_table_addr builder parent_addr idx with
   | Some next_addr -> next_addr
-  | None -> create_child_table builder parent_addr idx
+  | None -> create_child_table builder root parent_addr idx
 
 (** Align a VA or PA for the descriptor level being inserted. *)
 let check_aligned_at_level name level addr =
@@ -177,7 +267,7 @@ let check_aligned_at_level name level addr =
       level
 
 (** Write an encoded descriptor at [va], allocating intermediate tables. *)
-let write_descriptor ?(level = Desc.last_level) builder ~va desc =
+let write_descriptor ?(level = Desc.last_level) builder ~root ~va desc =
   let rec walk table_addr current_level =
     let idx = Desc.va_index va current_level in
     if current_level = level then
@@ -188,24 +278,32 @@ let write_descriptor ?(level = Desc.last_level) builder ~va desc =
            0x%Lx, new descriptor 0x%Lx"
            va existing desc
     else
-      let child_addr = ensure_child_table builder table_addr idx in
+      let child_addr = ensure_child_table builder root table_addr idx in
       walk child_addr (current_level + 1)
   in
-  walk builder.root Desc.root_level
+  walk root.base Desc.root_level
 
 (** Add the requested mapping, allocating intermediate tables on demand. *)
-let add_mapping ?(fields = []) ?(level = Desc.last_level) builder ~va ~pa kind =
+let add_mapping
+      ?(fields = [])
+      ?(level = Desc.last_level)
+      builder
+      ~root
+      ~va
+      ~pa
+      kind
+  =
   let va = check_aligned_at_level "VA" level va in
   let pa = check_aligned_at_level "PA" level pa in
   let desc =
     try Desc.make_descriptor ~fields ~level ~oa:pa ~kind ()
     with Failure msg -> error "page_table: %s" msg
   in
-  write_descriptor ~level builder ~va desc
+  write_descriptor ~level builder ~root ~va desc
 
-let add_code_mappings builder code_pages =
+let add_code_mappings builder ~root code_pages =
   List.iter
-    (fun addr -> add_mapping builder ~va:addr ~pa:addr Page_table_ast.Code)
+    (fun addr -> add_mapping builder ~root ~va:addr ~pa:addr Page_table_ast.Code)
     code_pages
 
 (** {1 Statement evaluation} *)
@@ -217,24 +315,19 @@ let check_table_level = function
         Desc.root_level (Desc.last_level - 1)
   | Some level -> level
 
-let addr_of_z name addr =
-  try Z.to_int addr
-  with Z.Overflow ->
-    error "page_table: %s out of range: %s" name (Z.format "%#x" addr)
-
 let mapping_alignment level =
   try Desc.level_size level
   with Invalid_argument _ -> error "page_table: invalid mapping level: %d" level
 
-let eval_mapping_target ?level ?(attrs = []) builder ~va = function
+let eval_mapping_target ?level ?(attrs = []) builder ~root ~va = function
   | Page_table_ast.PaName pa_name ->
       let alignment = Option.map mapping_alignment level in
-      let pa = alloc_pa ?alignment ?mapping_level:level builder pa_name in
-      add_mapping ?level ~fields:attrs builder ~va ~pa Page_table_ast.Data
+      let pa = alloc_physical ?alignment ?mapping_level:level builder pa_name in
+      add_mapping ?level ~fields:attrs builder ~root ~va ~pa Page_table_ast.Data
   | Page_table_ast.Invalid ->
       if attrs <> [] then
         error "page_table: descriptor fields are only supported on PA mappings";
-      write_descriptor ?level builder ~va 0L
+      write_descriptor ?level builder ~root ~va 0L
   | Page_table_ast.Table addr ->
       if attrs <> [] then
         error "page_table: descriptor fields are only supported on PA mappings";
@@ -244,9 +337,9 @@ let eval_mapping_target ?level ?(attrs = []) builder ~va = function
         try Desc.table_descriptor table_pa
         with Failure msg -> error "page_table: %s" msg
       in
-      write_descriptor ~level builder ~va desc
+      write_descriptor ~level builder ~root ~va desc
 
-let eval_stmt builder ~symbolic_vas = function
+let rec eval_stmt builder ~symbolic_vas ~root = function
   | Page_table_ast.Virtual _ -> ()
   | Page_table_ast.Physical names ->
       builder.declared_pas <- builder.declared_pas @ names
@@ -257,14 +350,17 @@ let eval_stmt builder ~symbolic_vas = function
         | Some addr -> addr
         | None -> error "page_table: undeclared VA: %s" va_name
       in
-      eval_mapping_target ?level ~attrs builder ~va target
+      eval_mapping_target ?level ~attrs builder ~root ~va target
   | Page_table_ast.MaybeMapping _ -> ()
   | Page_table_ast.DataInit {pa_name; value} ->
-      let pa = alloc_pa builder pa_name in
+      let pa = alloc_physical builder pa_name in
       builder.data_inits <- (pa, value) :: builder.data_inits
   | Page_table_ast.IdentityMapping {addr; attr} ->
       let addr = addr_of_z "address" addr in
-      add_mapping builder ~va:addr ~pa:addr attr
+      add_mapping builder ~root ~va:addr ~pa:addr attr
+  | Page_table_ast.TableBlock {stage; name; base = _; body} ->
+      let root = find_root builder ~stage ~name in
+      List.iter (eval_stmt builder ~symbolic_vas ~root) body
 
 (** {1 Layout construction} *)
 
@@ -277,26 +373,35 @@ let to_entries builder =
 
 (** Freeze the builder state into the immutable layout used downstream. *)
 let to_layout builder =
-  let root = builder.root in
+  let root = builder.default_root.base in
   let table_entries = to_entries builder in
-  (* Generated PA alias for the root translation-table page. *)
-  let symbols_pa = ("page_table_base", root) :: builder.symbols_pa in
-  let phys_symbols_pa = List.rev builder.symbols_pa in
+  let table_symbols_pa =
+    List.filter_map
+      (fun root -> Option.map (fun name -> (name, root.base)) root.name)
+      builder.named_roots
+    |> List.rev
+  in
+  let data_symbols_pa = List.rev builder.data_symbols_pa in
   let data_inits = builder.data_inits in
-  {root; table_entries; symbols_pa; phys_symbols_pa; data_inits}
+  {root; table_entries; table_symbols_pa; data_symbols_pa; data_inits}
 
-let build ~arch ~allocator ~symbolic_vas ~code_pages stmts =
+let build ~arch ~allocator ~symbolic_vas ~code_pages ~reserved_pages stmts =
   check_arch arch;
   if stmts = [] then error "page_table: empty page_table_setup";
   (* [root] is the TTBR0 value and the base of the 2MB page-table pool. *)
   let root = Allocator.alloc_big allocator in
-  let builder = make allocator ~root in
+  let builder = make allocator ~root ~reserved_pages in
+  let reserved_names =
+    "page_table_base" :: (List.map fst symbolic_vas @ declared_pa_names stmts)
+  in
+  reserve_table_roots builder ~reserved_names stmts;
   (* Page tables are identity-mapped so generated PTE VAs can access them. *)
-  add_mapping ~level:2 builder ~va:root ~pa:root Page_table_ast.Data;
+  add_mapping ~level:2 builder ~root:builder.default_root ~va:root ~pa:root
+    Page_table_ast.Data;
   (* Evaluate each statement, using symbolic VAs to resolve virtual names. *)
-  List.iter (eval_stmt builder ~symbolic_vas) stmts;
+  List.iter (eval_stmt builder ~symbolic_vas ~root:builder.default_root) stmts;
   (* Add code identity mappings after explicit page-table statements. *)
-  add_code_mappings builder code_pages;
+  add_code_mappings builder ~root:builder.default_root code_pages;
   (* Put data initializers back in source order. *)
   builder.data_inits <- List.rev builder.data_inits;
   to_layout builder

--- a/cli/lib/isla/page_table/page_table_builder.mli
+++ b/cli/lib/isla/page_table/page_table_builder.mli
@@ -54,10 +54,10 @@ type data_value = Z.t
 type layout =
   { root : pa;
     table_entries : (pa * descriptor) list;
-    (* Mapping from PA-side symbols to concrete PAs: pa_x -> PA. *)
-    symbols_pa : (string * pa) list;
-    (* PA-side data symbols, excluding generated root aliases. *)
-    phys_symbols_pa : (string * pa) list;
+    (* PA-side table root symbols. *)
+    table_symbols_pa : (string * pa) list;
+    (* PA-side data symbols. *)
+    data_symbols_pa : (string * pa) list;
     (* [*pa = value] initialisers resolved to concrete PAs. *)
     data_inits : (pa * data_value) list
   }
@@ -72,6 +72,8 @@ val build :
   symbolic_vas:(string * va) list ->
   (* Lists built-in thread code pages that should get identity mappings *)
   code_pages:va list ->
+  (* Physical pages already occupied by assembled code sections *)
+  reserved_pages:pa list ->
   (* Parsed [page_table_setup] statement list *)
   Page_table_ast.stmt list ->
   layout

--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -57,6 +57,8 @@
 %token SEMICOLON ";"
 %token LBRACKET "["
 %token RBRACKET "]"
+%token LBRACE "{"
+%token RBRACE "}"
 %token MAPS_TO "|->"
 %token MAYBE_MAPS_TO "?->"
 %token ALIGNED
@@ -70,6 +72,8 @@
 %token DATA
 %token INVALID
 %token TABLE
+%token S1TABLE
+%token S2TABLE
 %token AT
 %token LEVEL
 %token TRUE
@@ -83,12 +87,14 @@
 %start <Term.t> binding
 %start <Page_table_ast.stmt list> page_table_setup
 %type <Page_table_ast.stmt> page_table_stmt page_table_stmt_inner
+  page_table_block
 %type <Page_table_ast.mapping_target * Page_table_ast.descriptor_field list * int option>
   page_table_mapping_rhs
 %type <Page_table_ast.mapping_target> page_table_mapping_target
 %type <Page_table_ast.attr> page_table_attr
 %type <Page_table_ast.descriptor_field list> page_table_descriptor_attrs
 %type <int> page_table_mapping_level
+%type <Page_table_ast.table_stage> page_table_stage
 %type <string> kw_name
 
 %%
@@ -104,6 +110,7 @@ page_table_setup:
 
 page_table_stmt:
   | s = page_table_stmt_inner; ";" { s }
+  | b = page_table_block; option(";") { b }
 
 page_table_stmt_inner:
   | VIRTUAL; names = nonempty_list(IDENT)
@@ -124,6 +131,15 @@ page_table_stmt_inner:
     { Page_table_ast.DataInit {pa_name; value} }
   | IDENTITY; addr = NUM; WITH; attr = page_table_attr
     { Page_table_ast.IdentityMapping {addr; attr} }
+
+page_table_block:
+  | stage = page_table_stage; name = IDENT; base = NUM; "{";
+    body = list(page_table_stmt); "}"
+    { Page_table_ast.TableBlock {stage; name; base; body} }
+
+page_table_stage:
+  | S1TABLE { Page_table_ast.S1 }
+  | S2TABLE { Page_table_ast.S2 }
 
 page_table_mapping_rhs:
   | target = page_table_mapping_target;

--- a/cli/tests/arm/vm/SwitchTTBR+VM.litmus.toml
+++ b/cli/tests/arm/vm/SwitchTTBR+VM.litmus.toml
@@ -1,0 +1,30 @@
+arch = "AArch64"
+name = "SwitchTTBR+VM"
+symbolic = ["x"]
+
+page_table_setup = """
+physical pa0 pa1;
+*pa0 = 0;
+*pa1 = 1;
+
+s1table table0 0x400000 {
+  identity 0x1000 with code;
+  x |-> pa0;
+}
+
+s1table table1 0x300000 {
+  identity 0x1000 with code;
+  x |-> pa1;
+}
+"""
+
+[thread.0]
+init = { X0 = "table1", X2 = "x", TTBR0_EL1 = "table0", SCTLR_EL1 = 1, CurrentEL = 1 }
+code = """
+MSR TTBR0_EL1, X0
+MRS X3, TTBR0_EL1
+LDR X1, [X2]
+"""
+
+[final]
+assertion = "0:X1 = 1 & 0:X3 = table1"

--- a/cli/tests/converter/expect/arm/vm/SwitchTTBR+VM.litmus.toml
+++ b/cli/tests/converter/expect/arm/vm/SwitchTTBR+VM.litmus.toml
@@ -1,0 +1,161 @@
+arch = "Arm"
+name = "SwitchTTBR+VM"
+
+[[memory]]
+  sym = "__thread0"
+  kind = "code"
+  addr = 0x1000
+  step = 4
+  data = [0xd5182000, 0xd5382003, 0xf9400041]
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x200000
+  step = 8
+  data = 0x201003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x201000
+  step = 8
+  data = 0x202003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x202000
+  step = 8
+  data = 0x203003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x202008
+  step = 8
+  data = 0x200441
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x203008
+  step = 8
+  data = 0x14c3
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x300000
+  step = 8
+  data = 0x301003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x301000
+  step = 8
+  data = 0x302003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x302000
+  step = 8
+  data = 0x303003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x303008
+  step = 8
+  data = 0x14c3
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x303010
+  step = 8
+  data = 0x402443
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x400000
+  step = 8
+  data = 0x403003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x403000
+  step = 8
+  data = 0x404003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x404000
+  step = 8
+  data = 0x405003
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x405008
+  step = 8
+  data = 0x14c3
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x405010
+  step = 8
+  data = 0x401443
+
+[[memory]]
+  sym = "pa0"
+  addr = 0x401000
+  step = 8
+  data = 0
+
+[[memory]]
+  sym = "pa1"
+  addr = 0x402000
+  step = 8
+  data = 1
+
+[thread]
+
+[thread."0"]
+  breakpoints = [0x100c]
+
+[thread."0".regs]
+  _PC = 0x1000
+  "R0" = 0x300000
+  "R2" = 0x2000
+  "TTBR0_EL1" = 0x400000
+  "SCTLR_EL1" = 1
+  CurrentEL = 1
+  "R1" = 0
+  "R3" = 0
+  "R4" = 0
+  "R5" = 0
+  "R6" = 0
+  "R7" = 0
+  "R8" = 0
+  "R9" = 0
+  "R10" = 0
+  "R11" = 0
+  "R12" = 0
+  "R13" = 0
+  "R14" = 0
+  "R15" = 0
+  "R16" = 0
+  "R17" = 0
+  "R18" = 0
+  "R19" = 0
+  "R20" = 0
+  "R21" = 0
+  "R22" = 0
+  "R23" = 0
+  "R24" = 0
+  "R25" = 0
+  "R26" = 0
+  "R27" = 0
+  "R28" = 0
+  "R29" = 0
+  "R30" = 0
+  "TCR_EL1" = 0
+  "ID_AA64MMFR1_EL1" = 0
+  SPSel = 0
+  NZCV = 0
+  DAIF = 0
+
+[final]
+  assertion = {and = [{"0:X1" = 1}, {"0:X3" = 0x300000}]}

--- a/cli/tests/errors/conflicting-page-table-root-code.litmus.toml
+++ b/cli/tests/errors/conflicting-page-table-root-code.litmus.toml
@@ -1,0 +1,11 @@
+arch = "AArch64"
+name = "conflicting-page-table-root-code"
+
+page_table_setup = """
+s1table root 0x1000 {}
+"""
+
+[thread.0]
+code = """
+nop
+"""

--- a/cli/tests/errors/conflicting-page-table-root-symbol.litmus.toml
+++ b/cli/tests/errors/conflicting-page-table-root-symbol.litmus.toml
@@ -1,0 +1,12 @@
+arch = "AArch64"
+name = "conflicting-page-table-root-symbol"
+symbolic = ["x"]
+
+page_table_setup = """
+s1table x 0x2c0000 {}
+"""
+
+[thread.0]
+code = """
+nop
+"""

--- a/cli/tests/errors/duplicate-page-table-root-name.litmus.toml
+++ b/cli/tests/errors/duplicate-page-table-root-name.litmus.toml
@@ -1,0 +1,12 @@
+arch = "AArch64"
+name = "duplicate-page-table-root-name"
+
+page_table_setup = """
+s1table root 0x2c0000 {}
+s2table root 0x300000 {}
+"""
+
+[thread.0]
+code = """
+nop
+"""

--- a/cli/tests/errors/errors.t
+++ b/cli/tests/errors/errors.t
@@ -199,6 +199,27 @@ Page table DSL reports a stricter mapping alignment after PA assignment
   page_table: PA symbol pa_x at 0x601000 is not aligned for a level 2 mapping (requires 2097152 bytes)
   [1]
 
+Page table DSL rejects duplicate root names across translation stages
+  $ archsem seq duplicate-page-table-root-name.litmus.toml
+  archsem: eval error:
+  File "duplicate-page-table-root-name.litmus.toml", path "page_table_setup":
+  page_table: duplicate table root: root
+  [1]
+
+Page table DSL rejects root names that collide with address symbols
+  $ archsem seq conflicting-page-table-root-symbol.litmus.toml
+  archsem: eval error:
+  File "conflicting-page-table-root-symbol.litmus.toml", path "page_table_setup":
+  page_table: table root name conflicts with existing symbol: x
+  [1]
+
+Page table DSL rejects table roots that overlap code pages
+  $ archsem seq conflicting-page-table-root-code.litmus.toml
+  archsem: eval error:
+  File "conflicting-page-table-root-code.litmus.toml", path "page_table_setup":
+  page_table: table base 0x1000 overlaps existing memory page at 0x1000
+  [1]
+
 Page table DSL rejects locations with page tables
   $ archsem seq conflicting-page-table-data-init.litmus.toml
   archsem: eval error:


### PR DESCRIPTION
- Parse named s1table/s2table roots with explicit bases.
- Keep explicit roots reserved while building page tables.
- Cover switching between named roots with a VM smoke test.
