### PR TITLE
feat(Isla): Support page-table descriptor fields

### DIFF
--- a/cli/lib/isla/page_table/page_table_builder.ml
+++ b/cli/lib/isla/page_table/page_table_builder.ml
@@ -287,16 +287,13 @@ let eval_mapping_target ?level ?(attrs = []) builder ~root ~va = function
       let pa = alloc_physical ?alignment ?mapping_level:level builder pa_name in
       add_mapping ?level ~fields:attrs builder ~root ~va ~pa Page_table_ast.Data
   | Page_table_ast.Invalid ->
-      if attrs <> [] then
-        error "page_table: descriptor fields are only supported on PA mappings";
-      write_descriptor ?level builder ~root ~va 0L
+      let desc = Desc.apply_descriptor_fields 0L attrs in
+      write_descriptor ?level builder ~root ~va desc
   | Page_table_ast.Table addr ->
-      if attrs <> [] then
-        error "page_table: descriptor fields are only supported on PA mappings";
       let level = check_table_level level in
       let table_pa = addr_of_z "table address" addr in
       let desc =
-        try Desc.table_descriptor table_pa
+        try Desc.apply_descriptor_fields (Desc.table_descriptor table_pa) attrs
         with Failure msg -> error "page_table: %s" msg
       in
       write_descriptor ~level builder ~root ~va desc

--- a/cli/lib/isla/page_table/page_table_desc.ml
+++ b/cli/lib/isla/page_table/page_table_desc.ml
@@ -91,8 +91,12 @@ let descriptor_fields =
   [ {name = "Valid"; lsb = 0; width = 1};
     {name = "AF"; lsb = 10; width = 1};
     {name = "AP"; lsb = 6; width = 2};
-    {name = "DBM"; lsb = 51; width = 1}
+    {name = "DBM"; lsb = 51; width = 1};
+    {name = "nG"; lsb = 11; width = 1};
+    {name = "APTable"; lsb = 61; width = 2}
   ]
+
+let descriptor_field_names = List.map (fun field -> field.name) descriptor_fields
 
 (** Replace the bits selected by [mask] with [bits], preserving all other bits. *)
 let update_bits desc mask bits =

--- a/cli/lib/isla/page_table/page_table_fns.ml
+++ b/cli/lib/isla/page_table/page_table_fns.ml
@@ -56,10 +56,17 @@ let asid_function =
     | args -> Fn_registry.arity_error "asid" 1 (List.length args)
   )
 
-let descriptor_field_arg kwargs field_name default =
-  { Page_table_ast.name = field_name;
-    value = Fn_registry.optional_kwarg field_name default kwargs
-  }
+let descriptor_fields_of_kwargs ?(defaults = []) kwargs =
+  List.filter_map
+    (fun name ->
+       match List.assoc_opt name kwargs with
+       | Some value -> Some Page_table_ast.{name; value}
+       | None ->
+           Option.map
+             (fun value -> Page_table_ast.{name; value})
+             (List.assoc_opt name defaults)
+     )
+    Page_table_desc.descriptor_field_names
 
 (** Find the page-table entry address for [va] at [level]. *)
 let pte_addr name entries ~base ~va ~level =
@@ -122,15 +129,14 @@ let desc_function entries level =
 
 (** [mkdescN(oa=..., ...)] encodes a level-[N] block/page descriptor. *)
 let eval_desc name level kwargs =
-  Fn_registry.check_kwargs name ["oa"; "Valid"; "AF"; "AP"; "DBM"] kwargs;
+  Fn_registry.check_kwargs name
+    ("oa" :: Page_table_desc.descriptor_field_names)
+    kwargs;
   let oa = Fn_registry.required_kwarg name "oa" kwargs in
-  let fields =
-    [ descriptor_field_arg kwargs "Valid" Z.one;
-      descriptor_field_arg kwargs "AF" Z.one;
-      descriptor_field_arg kwargs "AP" Z.one;
-      descriptor_field_arg kwargs "DBM" Z.zero
-    ]
+  let defaults =
+    [("Valid", Z.one); ("AF", Z.one); ("AP", Z.one); ("DBM", Z.zero)]
   in
+  let fields = descriptor_fields_of_kwargs ~defaults kwargs in
   Z.of_int64
     (Page_table_desc.make_descriptor ~level
        ~oa:(Fn_registry.int_arg name "oa" oa)
@@ -139,11 +145,16 @@ let eval_desc name level kwargs =
 
 (** [mkdescN(table=...)] encodes a next-level table descriptor. *)
 let eval_table_desc name kwargs =
-  Fn_registry.check_kwargs name ["table"] kwargs;
+  Fn_registry.check_kwargs name
+    ("table" :: Page_table_desc.descriptor_field_names)
+    kwargs;
   let table_addr = Fn_registry.required_kwarg name "table" kwargs in
+  let desc =
+    Page_table_desc.table_descriptor (Fn_registry.int_arg name "table" table_addr)
+  in
   Z.of_int64
-    (Page_table_desc.table_descriptor
-       (Fn_registry.int_arg name "table" table_addr)
+    (Page_table_desc.apply_descriptor_fields desc
+       (descriptor_fields_of_kwargs kwargs)
     )
 
 let mkdesc_function level =

--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -155,18 +155,20 @@ page_table_mapping_rhs:
     attrs = option(page_table_descriptor_attrs);
     level = option(page_table_mapping_level)
     { (target, Option.value ~default:[] attrs, level) }
-  | TABLE; "("; addr = NUM; ")"; level = page_table_mapping_level
-    { (Page_table_ast.Table addr, [], Some level) }
 
 page_table_mapping_target:
   | name = IDENT { Page_table_ast.PaName name }
   | INVALID { Page_table_ast.Invalid }
+  | TABLE; "("; addr = NUM; ")" { Page_table_ast.Table addr }
 
 page_table_descriptor_attrs:
   | WITH; "[";
     attrs = separated_nonempty_list(",", page_table_descriptor_attr);
-    "]"; AND_KW; DEFAULT
+    "]"; option(page_table_descriptor_default)
     { attrs }
+
+page_table_descriptor_default:
+  | AND_KW; DEFAULT { () }
 
 %inline page_table_descriptor_attr:
   | name = IDENT; "="; value = NUM


### PR DESCRIPTION
- Parse descriptor attributes on table(...) mappings with or without and default.
- Add nG and APTable to the descriptor field encoder.
- Allow mkdescN(table=..., APTable=...) and mkdescN(oa=..., nG=...) keyword arguments.
- Apply explicit descriptor fields to table and invalid descriptors during page-table setup.
