### PR TITLE
feat(Isla): Support page-table references

### DIFF
--- a/cli/lib/isla/page_table/page_table_ast.ml
+++ b/cli/lib/isla/page_table/page_table_ast.ml
@@ -105,3 +105,8 @@ type stmt =
         base : Z.t;
         body : stmt list
       }
+  (* [s1table name;] references a previously declared named table. *)
+  | TableRef of
+      { stage : table_stage;
+        name : string
+      }

--- a/cli/lib/isla/page_table/page_table_builder.ml
+++ b/cli/lib/isla/page_table/page_table_builder.ml
@@ -268,6 +268,32 @@ let add_code_mappings builder ~root code_pages =
     (fun addr -> add_mapping builder ~root ~va:addr ~pa:addr Page_table_ast.Code)
     code_pages
 
+let table_pages_reachable_from builder root =
+  let entries_per_table = Desc.table_size / Desc.entry_size in
+  let rec visit seen table_addr =
+    if List.mem table_addr seen then seen
+    else
+      let rec visit_entries seen idx =
+        if idx = entries_per_table then seen
+        else
+          let seen =
+            match child_table_addr builder table_addr idx with
+            | Some child_addr when List.mem child_addr builder.table_pages ->
+                visit seen child_addr
+            | Some _ | None -> seen
+          in
+          visit_entries seen (idx + 1)
+      in
+      visit_entries (table_addr :: seen) 0
+  in
+  List.rev (visit [] root.base)
+
+let map_table_pages builder ~root ~source =
+  table_pages_reachable_from builder source
+  |> List.iter (fun page ->
+    add_mapping builder ~root ~va:page ~pa:page Page_table_ast.Data
+  )
+
 (** {1 Statement evaluation} *)
 
 let check_table_level = function
@@ -322,6 +348,9 @@ let rec eval_stmt builder ~symbolic_vas ~root = function
   | Page_table_ast.TableBlock {stage; name; base = _; body} ->
       let root = find_root builder ~stage ~name in
       List.iter (eval_stmt builder ~symbolic_vas ~root) body
+  | Page_table_ast.TableRef {stage; name} ->
+      let source = find_root builder ~stage ~name in
+      map_table_pages builder ~root ~source
 
 (** {1 Layout construction} *)
 

--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -140,6 +140,8 @@ page_table_stmt_inner:
     { Page_table_ast.DataInit {pa_name; value} }
   | IDENTITY; addr = NUM; WITH; attr = page_table_attr
     { Page_table_ast.IdentityMapping {addr; attr} }
+  | stage = page_table_stage; name = IDENT
+    { Page_table_ast.TableRef {stage; name} }
 
 page_table_block:
   | stage = page_table_stage; name = IDENT; base = NUM; "{";


### PR DESCRIPTION
- Parse s1table/s2table reference statements inside page-table setup blocks.
- Track named table stages while reserving explicit table roots.
- Validate referenced table names and stages during page-table setup evaluation.
