### PR TITLE
feat(Isla): Support TTBR page-table helper

### DIFF
--- a/cli/lib/isla/page_table/page_table_fns.ml
+++ b/cli/lib/isla/page_table/page_table_fns.ml
@@ -48,11 +48,13 @@ let page_function =
     | args -> Fn_registry.arity_error "page" 1 (List.length args)
   )
 
+let shift_ttbr_id id = Z.shift_left id 48
+
 (** [asid(v)] shifts an ASID value into bits [63:48]. *)
 let asid_function =
   ( "asid",
     function
-    | [v] -> Z.shift_left v 48
+    | [v] -> shift_ttbr_id v
     | args -> Fn_registry.arity_error "asid" 1 (List.length args)
   )
 
@@ -169,6 +171,22 @@ let mkdesc_function level =
   in
   (name, eval)
 
+(** [ttbr(asid=..., base=...)] and [ttbr(vmid=..., base=...)] pack the
+    translation-table identity into the upper TTBR bits. *)
+let ttbr_function =
+  let name = "ttbr" in
+  let eval kwargs =
+    Fn_registry.check_kwargs name ["asid"; "vmid"; "base"] kwargs;
+    let base = Fn_registry.required_kwarg name "base" kwargs in
+    let id =
+      match (List.assoc_opt "asid" kwargs, List.assoc_opt "vmid" kwargs) with
+      | (Some id, None) | (None, Some id) -> id
+      | _ -> Fn_registry.error "%s: expected exactly one of asid or vmid" name
+    in
+    Z.logor base (shift_ttbr_id id)
+  in
+  (name, eval)
+
 let positional_functions ?page_table_entries () =
   let functions = [page_function; asid_function] in
   match page_table_entries with
@@ -181,4 +199,4 @@ let positional_functions ?page_table_entries () =
 
 let keyword_functions : Fn_registry.keyword_fn list =
   let levels = [0; 1; 2; 3] in
-  List.map mkdesc_function levels
+  ttbr_function :: List.map mkdesc_function levels

--- a/cli/tests/arm/vm/SwitchTTBR+VM.litmus.toml
+++ b/cli/tests/arm/vm/SwitchTTBR+VM.litmus.toml
@@ -19,7 +19,7 @@ s1table table1 0x300000 {
 """
 
 [thread.0]
-init = { X0 = "table1", X2 = "x", TTBR0_EL1 = "table0", SCTLR_EL1 = 1, CurrentEL = 1 }
+init = { X0 = "ttbr(asid=0x2, base=table1)", X2 = "x", TTBR0_EL1 = "ttbr(asid=0x1, base=table0)", SCTLR_EL1 = 1, CurrentEL = 1 }
 code = """
 MSR TTBR0_EL1, X0
 MRS X3, TTBR0_EL1
@@ -27,4 +27,4 @@ LDR X1, [X2]
 """
 
 [final]
-assertion = "0:X1 = 1 & 0:X3 = table1"
+assertion = "0:X1 = 1 & 0:X3 = ttbr(asid=0x2, base=table1)"

--- a/cli/tests/converter/expect/arm/vm/SwitchTTBR+VM.litmus.toml
+++ b/cli/tests/converter/expect/arm/vm/SwitchTTBR+VM.litmus.toml
@@ -117,9 +117,9 @@ name = "SwitchTTBR+VM"
 
 [thread."0".regs]
   _PC = 0x1000
-  "R0" = 0x300000
+  "R0" = 0x2000000300000
   "R2" = 0x2000
-  "TTBR0_EL1" = 0x2c0000
+  "TTBR0_EL1" = 0x10000002c0000
   "SCTLR_EL1" = 1
   CurrentEL = 1
   "R1" = 0
@@ -158,4 +158,4 @@ name = "SwitchTTBR+VM"
   DAIF = 0
 
 [final]
-  assertion = {and = [{"0:X1" = 1}, {"0:X3" = 0x300000}]}
+  assertion = {and = [{"0:X1" = 1}, {"0:X3" = 0x2000000300000}]}


### PR DESCRIPTION
- Add ttbr(asid=..., base=...) and ttbr(vmid=..., base=...) to pack ASID/VMID bits into TTBR values.
- Cover the helper in the Alias+VM parser and converter expectations.
