### PR TITLE
fix(VMPromising): Fix BBM violation detection

### DIFF
--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -2464,10 +2464,12 @@ Section BBM.
 
   (** Check if a physical address falls within the address range
       covered by a given output address prefix. *)
-  Definition is_addr_from_oa {n : N} (addr : address) (oa : bv n) : Prop :=
-    bv_extract (56 - n) n addr = oa.
-  Instance Decision_is_addr_from_oa {n : N} (addr : address) (oa : bv n) :
-    Decision (is_addr_from_oa addr oa).
+  Definition is_addr_from_oa (lvl : Level) (addr : address)
+      (oa : bv (output_addr_size lvl)) : Prop :=
+    bv_extract (offset_size lvl) (output_addr_size lvl) addr = oa.
+  Instance Decision_is_addr_from_oa (lvl : Level) (addr : address)
+      (oa : bv (output_addr_size lvl)) :
+    Decision (is_addr_from_oa lvl addr oa).
   Proof. unfold_decide. Defined.
 
   (** Compare memory contents at two output addresses.
@@ -2478,15 +2480,15 @@ Section BBM.
                 (lvl : Level)
                 (oa1 oa2 : bv (output_addr_size lvl))
                 (relevant_addrs : list address) : Prop :=
-    let offset_bits := (56 - output_addr_size lvl)%N in
+    let offset_bits := offset_size lvl in
     let relevant_offs :=
       omap (λ addr,
-        if decide (is_addr_from_oa addr oa1 ∨ is_addr_from_oa addr oa2)
+        if decide (is_addr_from_oa lvl addr oa1 ∨ is_addr_from_oa lvl addr oa2)
           then Some (bv_extract 0 offset_bits addr)
           else None) relevant_addrs in
     ∀ offs ∈ relevant_offs,
-      let addr1 := bv_concat 56 oa1 offs in
-      let addr2 := bv_concat 56 oa2 offs in
+      let addr1 := bv_concat 56 (bv_0 8) (bv_concat 48 oa1 offs) in
+      let addr2 := bv_concat 56 (bv_0 8) (bv_concat 48 oa2 offs) in
       let byte1 := Memory.read_byte addr1 init mem time in
       let byte2 := Memory.read_byte addr2 init mem time in
       match byte1, byte2 with
@@ -2513,10 +2515,14 @@ Section BBM.
       let va1 := TLB.Ctxt.va c1 in
       let va2 := TLB.Ctxt.va c2 in
       if decide (lvl1 ≤ lvl2)%fin then
-        let va2_trunc : prefix lvl1 := bv_extract 0 (level_length lvl1) va2 in
+        let va2_trunc : prefix lvl1 :=
+          bv_extract (level_length lvl2 - level_length lvl1)
+            (level_length lvl1) va2 in
         va1 =? va2_trunc
       else
-        let va1_trunc : prefix lvl2 := bv_extract 0 (level_length lvl2) va1 in
+        let va1_trunc : prefix lvl2 :=
+          bv_extract (level_length lvl1 - level_length lvl2)
+            (level_length lvl2) va1 in
         va1_trunc =? va2.
 
   (** Check for BBM violation between two TLB entries. *)


### PR DESCRIPTION
Current BBM validation could fail to relate translations that cover the same virtual-address range.

For cross-level translations:
```
L2 context prefix: P
L3 context prefix: P || index

expected: truncate_to_L2(P || index) = P
previous: bv_extract 0 (level_length L2) (P || index) ≠ P
```

Another case was:
```
Initial state:
  VA      = 0x8000001000
  L2[0]   = 0
  L3[1]   = 0x60000000001783  // PA 0x1000

Execution:
  L2[0] := 0x83003             // link L3
  load VA                      // returns 0x2a

  L3[1] := 0x60000000002783    // valid-to-valid, no break/TLBI
  load VA                      // returns 0x42
```
BBM.Strict previously accepted this execution.