### PR TITLE
ArchSemArm: add the acq-rel AMO full-barrier bob clause (UMArm + VMSA22Arm)

### DIFF
--- a/ArchSemArm/UMArm.v
+++ b/ArchSemArm/UMArm.v
@@ -180,6 +180,15 @@ Section UMArm.
     ∪ (⦗W⦘⨾po⨾⦗dmb_store cd⦘)
     ∪ (⦗dmb cd⦘⨾po⨾⦗W⦘)
     ∪ (⦗dmb_load cd⦘⨾po⨾⦗R⦘)
+    (* Forward edge out of an acquire-release AMO write, absent from the ESOP'22
+       bob this model tracks.  The property is in aarch64.cat since 2018 (herd
+       a6c15616, Luc Maranget) and was strengthened to this range(...) form in
+       2022 (herd PR #322, 636b7163); herd aarch64hwreqs.cat:135.  We take the [M]
+       (explicit-memory) target, matching the sibling acquire/release clauses
+       below ([A ∪ Q]; po; [M] and [M]; po; [L]), which likewise target [M]; the
+       [Imp & Tag & R] / [MMU & FAULT] targets of the full clause are ordered by
+       other ob components (there are none in this user-mode model), not by bob. *)
+    ∪ (⦗grel_rng (⦗A⦘⨾amo⨾⦗L⦘)⦘⨾po⨾⦗M⦘)
     ∪ (⦗L⦘⨾po⨾⦗A⦘)
     ∪ (⦗A ∪ Q⦘⨾po⨾⦗M⦘)
     ∪ (⦗M⦘⨾po⨾⦗L⦘)

--- a/ArchSemArm/VMSA22Arm.v
+++ b/ArchSemArm/VMSA22Arm.v
@@ -630,6 +630,17 @@ Section VMSAArm.
     ∪ (⦗W⦘⨾po⨾⦗dmb_store cd⦘)
     ∪ (⦗dmb cd⦘⨾po⨾⦗W⦘)
     ∪ (⦗dmb_load cd⦘⨾po⨾⦗R⦘)
+    (* Forward edge out of an acquire-release AMO write, absent from the ESOP'22
+       bob this model tracks.  The property is in aarch64.cat since 2018 (herd
+       a6c15616, Luc Maranget) and was strengthened to this range(...) form in
+       2022 (herd PR #322, 636b7163); herd aarch64hwreqs.cat:135.  We take the [M]
+       (explicit-memory) target, matching the sibling acquire/release clauses
+       below ([A ∪ Q]; po; [M] and [M]; po; [L]), which likewise target [M].  This
+       model does define Fault effects (Fault_T/Fault_P, used in obfault) and Tag
+       reads, but bob's acquire/release clauses order only [M]; fault/tag ordering
+       comes from other ob components (obfault, tob, obtlbi, ...).  Kept identical
+       to UMArm.bob so UM_to_VMSA_bob still holds. *)
+    ∪ (⦗grel_rng (⦗A⦘⨾amo⨾⦗L⦘)⦘⨾po⨾⦗M⦘)
     ∪ (⦗L⦘⨾po⨾⦗A⦘)
     ∪ (⦗A ∪ Q⦘⨾po⨾⦗M⦘)
     ∪ (⦗M⦘⨾po⨾⦗L⦘)


### PR DESCRIPTION
UMArm and VMSA22Arm track the ESOP'22 Arm model and are missing one clause the current Arm application-level model has: the forward edge out of an acquire-release AMO write,

  [herd/libdir/aarch64hwreqs.cat:135](https://github.com/herd/herdtools7/blob/master/herd/libdir/aarch64hwreqs.cat#L135)
```
    [range([Exp & R & A]; amo; [Exp & W & L])]; po; [Exp & M | ...]
```
i.e. the property that an atomic with both acquire and release semantics acts as a full barrier.  This property has been in the Arm model since 2018 -- herd https://github.com/herd/herdtools7/commit/a6c15616d3f1e6ba53c012a1a536a4404006e06e (Luc Maranget, "herd: Implement atomic operations ADD and EOR"), originally `po; ([A];amo;[L]); po` -- and was strengthened to this `range(...)` forward-edge form in 2022, https://github.com/herd/herdtools7/commit/636b7163c0679c691b8cf9a04623cd3aa1cc0ec3 (PR #322, "Atomics with both acquire and release semantics currently act as a full barrier", Jade Alglave). It was most recently reworded in 2025-12 by https://github.com/herd/herdtools7/commit/003ec3289ca2781e9823c8beb8bd45b6ecef1279 (Fault-Effects relaxation).

The clause is added identically to UMArm.bob and VMSA22Arm.bob (user-mode projection: target [M]; the full model's `[Imp & Tag & R] / [MMU & FAULT]` targets do not occur in these models).  Keeping the two bob definitions in sync preserves VMUMEquivThm.UM_to_VMSA_bob (VMSA.bob = UM.bob), so the whole of ArchSemArm still builds.