### PR TITLE
chore(arm): Update sail-tiny-arm and stdpp pins

### DIFF
--- a/archsem.opam.locked
+++ b/archsem.opam.locked
@@ -124,11 +124,11 @@ pin-depends: [
   ]
   [
     "coq-stdpp.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   [
     "coq-stdpp-bitvector.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   [
     "menhir.20250912"

--- a/coq-archsem-arm.opam.locked
+++ b/coq-archsem-arm.opam.locked
@@ -138,15 +138,15 @@ pin-depends: [
   ]
   [
     "coq-sail-tiny-arm.dev"
-    "git+https://github.com/rems-project/sail-tiny-arm.git#5293f045"
+    "git+https://github.com/rems-project/sail-tiny-arm.git#90f09c6f"
   ]
   [
     "coq-stdpp.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   [
     "coq-stdpp-bitvector.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   ["libsail.0.20" "git+https://github.com/rems-project/sail.git#89f1a2f4"]
   [

--- a/coq-archsem-common.opam.locked
+++ b/coq-archsem-common.opam.locked
@@ -102,11 +102,11 @@ pin-depends: [
   ]
   [
     "coq-stdpp.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   [
     "coq-stdpp-bitvector.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   [
     "ocaml-variants.4.14.2+options"

--- a/coq-archsem-riscv.opam.locked
+++ b/coq-archsem-riscv.opam.locked
@@ -142,11 +142,11 @@ pin-depends: [
   ]
   [
     "coq-stdpp.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   [
     "coq-stdpp-bitvector.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   ["libsail.0.20" "git+https://github.com/rems-project/sail.git#89f1a2f4"]
   [

--- a/coq-archsem-x86.opam.locked
+++ b/coq-archsem-x86.opam.locked
@@ -142,11 +142,11 @@ pin-depends: [
   ]
   [
     "coq-stdpp.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   [
     "coq-stdpp-bitvector.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   ["libsail.0.20" "git+https://github.com/rems-project/sail.git#89f1a2f4"]
   [

--- a/coq-archsem.opam.locked
+++ b/coq-archsem.opam.locked
@@ -100,11 +100,11 @@ pin-depends: [
   ]
   [
     "coq-stdpp.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   [
     "coq-stdpp-bitvector.1.12.0"
-    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.12.0.tar.gz"
+    "git+https://gitlab.mpi-sws.org/iris/stdpp.git#coq-stdpp-1.12.0"
   ]
   [
     "ocaml-variants.4.14.2+options"


### PR DESCRIPTION
- Set sail-tiny-arm to the latest version.
- The stdpp archive endpoint repeatedly returned HTTP 429 in CI.