### PR TITLE
fix(vmp): detect BBM violations in late-linked tables

### DIFF
--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -2464,10 +2464,12 @@ Section BBM.
 
   (** Check if a physical address falls within the address range
       covered by a given output address prefix. *)
-  Definition is_addr_from_oa {n : N} (addr : address) (oa : bv n) : Prop :=
-    bv_extract (56 - n) n addr = oa.
-  Instance Decision_is_addr_from_oa {n : N} (addr : address) (oa : bv n) :
-    Decision (is_addr_from_oa addr oa).
+  Definition is_addr_from_oa (lvl : Level) (addr : address)
+      (oa : bv (output_addr_size lvl)) : Prop :=
+    bv_extract (offset_size lvl) (output_addr_size lvl) addr = oa.
+  Instance Decision_is_addr_from_oa (lvl : Level) (addr : address)
+      (oa : bv (output_addr_size lvl)) :
+    Decision (is_addr_from_oa lvl addr oa).
   Proof. unfold_decide. Defined.
 
   (** Compare memory contents at two output addresses.
@@ -2478,15 +2480,15 @@ Section BBM.
                 (lvl : Level)
                 (oa1 oa2 : bv (output_addr_size lvl))
                 (relevant_addrs : list address) : Prop :=
-    let offset_bits := (56 - output_addr_size lvl)%N in
+    let offset_bits := offset_size lvl in
     let relevant_offs :=
       omap (λ addr,
-        if decide (is_addr_from_oa addr oa1 ∨ is_addr_from_oa addr oa2)
+        if decide (is_addr_from_oa lvl addr oa1 ∨ is_addr_from_oa lvl addr oa2)
           then Some (bv_extract 0 offset_bits addr)
           else None) relevant_addrs in
     ∀ offs ∈ relevant_offs,
-      let addr1 := bv_concat 56 oa1 offs in
-      let addr2 := bv_concat 56 oa2 offs in
+      let addr1 := bv_concat 56 (bv_0 8) (bv_concat 48 oa1 offs) in
+      let addr2 := bv_concat 56 (bv_0 8) (bv_concat 48 oa2 offs) in
       let byte1 := Memory.read_byte addr1 init mem time in
       let byte2 := Memory.read_byte addr2 init mem time in
       match byte1, byte2 with

--- a/cli/tests/arm/vm/BBMLateLink.archsem.toml
+++ b/cli/tests/arm/vm/BBMLateLink.archsem.toml
@@ -1,0 +1,151 @@
+arch = "Arm"
+name = "BBMLateLink"
+
+# Link a populated L3 into the translation tree, read its old mapping, then
+# overwrite the leaf valid-to-valid without a break or TLBI.
+[thread.0.regs]
+_PC = 0x500
+R0 = 0x8000001000
+R1 = 0
+R2 = 0x10000
+R3 = 0x83003
+R4 = 0x60000000002783
+R5 = 0
+R6 = 0x11008
+R7 = 0
+R8 = 0
+TTBR0_EL1 = 0x80000
+TCR_EL1 = 0
+SCTLR_EL1 = 1
+ESR_EL1 = 0
+FAR_EL1 = 0
+ELR_EL1 = 0
+VBAR_EL1 = 0
+ID_AA64MMFR1_EL1 = 0x2000000000
+CurrentEL = 0b01
+
+[[memory]]
+addr = 0x500
+kind = "code"
+step = 4
+data = [
+  0xd5033b9f, # DSB ISH
+  0xd508831f, # TLBI VMALLE1IS
+  0xd5033b9f, # DSB ISH
+  0xf8226903, # STR X3, [X8, X2] - link the hidden L3
+  0xd5033a9f, # DSB ISHST
+  0xd5033fdf, # ISB
+  0xf8606825, # LDR X5, [X1, X0] - read PA 0x1000
+  0xf8266904, # STR X4, [X8, X6] - overwrite L3[1]
+  0xd5033a9f, # DSB ISHST
+  0xd5033fdf, # ISB
+  0xf8606827, # LDR X7, [X1, X0] - read PA 0x2000
+]
+
+[thread.0]
+breakpoints = [0x52c]
+
+[[memory]]
+addr = 0x1000
+step = 8
+data = 0x2a
+
+[[memory]]
+addr = 0x2000
+step = 8
+data = 0x42
+
+# Strict traversal reads every slot of each page-table page.  A 4096-byte
+# zero block makes all 512 slots present before the descriptors below override
+# the few nonzero entries.
+[[memory]]
+addr = 0x80000
+step = 4096
+data = 0
+
+[[memory]]
+addr = 0x81000
+step = 4096
+data = 0
+
+[[memory]]
+addr = 0x82000
+step = 4096
+data = 0
+
+[[memory]]
+addr = 0x83000
+step = 4096
+data = 0
+
+[[memory]]
+addr = 0x84000
+step = 4096
+data = 0
+
+[[memory]]
+addr = 0x85000
+step = 4096
+data = 0
+
+[[memory]]
+addr = 0x86000
+step = 4096
+data = 0
+
+# Root: index 0 is the code/alias hierarchy; index 1 is the data hierarchy.
+[[memory]]
+addr = 0x80000
+step = 8
+data = 0x84003
+
+[[memory]]
+addr = 0x80008
+step = 8
+data = 0x81003
+
+[[memory]]
+addr = 0x84000
+step = 8
+data = 0x85003
+
+[[memory]]
+addr = 0x85000
+step = 8
+data = 0x86003
+
+# Code plus writable aliases for data L2[0] and the hidden L3.
+[[memory]]
+addr = 0x86000
+step = 8
+data = 0x40000000000783
+
+[[memory]]
+addr = 0x86080
+step = 8
+data = 0x60000000082703
+
+[[memory]]
+addr = 0x86088
+step = 8
+data = 0x60000000083703
+
+[[memory]]
+addr = 0x81000
+step = 8
+data = 0x82003
+
+# L2[0] starts invalid, but the unlinked L3 already maps the target VA.
+[[memory]]
+addr = 0x82000
+step = 8
+data = 0
+
+[[memory]]
+addr = 0x83008
+step = 8
+data = 0x60000000001783
+
+[final]
+kind = "exists"
+assertion.and = [{"0:R5" = 0x2a}, {"0:R7" = 0x42}]


### PR DESCRIPTION
## Summary

- project BBM output-address regions with the translation level's actual offset
- add a fully backed CLI regression for a late-linked valid-to-valid leaf remap
- preserve the equal-content exemption for read-only mappings and BBM.Off execution behavior

## Root cause

`mem_contents_eq` derived the mapped offset from the 56-bit physical-address width instead of the 48-bit output-address encoding. For an L3 descriptor, that selected addresses starting at bit 20 rather than bit 12. Consequently, PA `0x1000` and `0x2000` were absent from `relevant_offs`, so the old and new read-only mappings compared equal vacuously and `has_bbm_violation` missed the remap.

The validation layer now uses `offset_size lvl` both when selecting relevant addresses and when rebuilding the two physical addresses. Translation execution and BBM.Off are unchanged.

## Validation

- `opam exec --switch=/Volumes/Codespaces/rems-project/archsem -- dune build --root . -j 1 ArchSemArm/VMPromising.vo`
- `opam exec --switch=/Volumes/Codespaces/rems-project/archsem -- dune build --root . -j 1 @ArchSemArm/tests/runtest @cli/tests/arm/runtest`
- `BBMLateLink`: rejected with `BBM violation detected` under Strict and Lax; allowed under Off with the `R5=0x2a, R7=0x42` witness
- `LDRPT+NoBBM`: still rejected under Lax
- `BBMSuccess`: still allowed under Lax

No changes to `ArchSemArm/tests/VMPromisingTest.v` are included.
