### PR TITLE
refactor(x86-TSO): Convert x86-TSO to opmodel setup

### DIFF
--- a/ArchSemX86/OperationalX86TSO.v
+++ b/ArchSemX86/OperationalX86TSO.v
@@ -326,7 +326,9 @@ Section Model.
         msetv ((.!!! tid) ∘ buf) t
     end.
 
-  Context (isem : iMon ()) (term : terminationCondition threads).
+  Context (isem : iMon ()).
+  Section steps.
+  Context (term : terminationCondition threads).
 
   (** ** Execution step transition *)
   Definition execution_step (tid : fin threads) (eager : bool)
@@ -367,6 +369,8 @@ Section Model.
       mret (Some tid).
 
   (** ** Eager transition functions *)
+
+  (** Run an eager transition *)
   Definition run_eager_thread_step (tid : fin threads) :
       Exec.t mstate string bool :=
     (* Eagerly run single thread instruction if possible.
@@ -384,6 +388,8 @@ Section Model.
           Exec.lift_res_st new_outcome;;
           mret true.
 
+  (** Runs all possible eager transition in a given thread [tid].
+      Returns the remaining fuel *)
   Fixpoint run_eager_thread (fuel : nat) (tid : fin threads) :
       Exec.t mstate string nat :=
     (* Run as many instructions as possible for this thread *)
@@ -395,10 +401,19 @@ Section Model.
       else mret (S fuel)
     else mthrow "Out of fuel".
 
+  (** Runs all possible transition in all threads. *)
   Definition run_eager_all (fuel : nat) : Exec.t mstate string nat :=
     (* For each thread, run as many instructions as possible *)
     foldlM run_eager_thread fuel (enum (fin threads)).
 
+  (** Run a non-eager step and then as many eager steps as possible,
+      assuming no eager step could be taken before the normal step *)
+  Definition run_normal_then_eager (fuel : nat) : Exec.t mstate string () :=
+    eager_thread ← step;
+    if eager_thread is Some tid then
+      run_eager_thread fuel tid;;
+      mret ()
+    else mret ().
 
 
   (** * Lift to executable archModel *)
@@ -429,81 +444,52 @@ Section Model.
     if decide (archState.is_terminated term astate) is left p then
       Some (existT astate p)
     else None.
+  End steps.
 
-  (** ** No-eager-transitions runner *)
-
-  (** Just take non-eager transition until reaching termination *)
-  Fixpoint run_to_term_no_eager (fuel : nat) :
-    Exec.t mstate string {s : archState threads & archState.is_terminated term s} :=
-    (* run until out of fuel or conditions met *)
-    if fuel is S fuel then
-      (* Run a non-eager execution step *)
-      step;;
-      (* Check if termination condition met. If not, execute non-eager step *)
-      fstate ← mget to_terminated_archState;
-      if fstate is Some fs then mret fs else run_to_term_no_eager fuel
-    else mthrow "Out of fuel".
+  (** The unoptimised X86-TSO model. Take one step per instruction or flushing
+      transitions. Need [fuel] for all instruction + all flushed writes + 1 for the
+      terminating step *)
+  Definition x86_tso_opmodel : opModel threads :=
+    let opstep term _ _ :=
+      fstate ← mget (to_terminated_archState term);
+      if fstate is Some fs then mret (Some fs) else
+        step term;;
+        mret None
+    in
+    opModel.Make threads mstate from_archState opstep.
 
 
-  (** ** Eager-transition-enabled runner *)
-
-  (** [run_to_term_eager_normal fuel] Assumes that no eager transition is
-      possible and does a normal transition.
-
-      [run_to_term_eager_eager fuel tid] Does all possible transition in thread
-      [tid] then goes back to the "normal" runner. *)
-  Fixpoint run_to_term_eager_normal (fuel : nat) :
-      Exec.t mstate string _ :=
-    (* run until out of fuel or conditions met *)
-    if fuel is S fuel then
-      (* Run a non-eager execution step *)
-      eager_thread ← step;
-      if eager_thread is Some tid then
-        run_to_term_eager_eager fuel tid
+  (** The X86-TSO model with eager steps. The fuel of of the previous model plus
+      one is guaranteed to be sufficient but some lower fuel might work
+      depending on the interleaving of eager and non-eager steps. *)
+  Definition x86_tso_opmodel_eager : opModel threads :=
+    let init term initSt := (from_archState term initSt, true) in
+    let step term _ fuel :=
+      fstate ← mget (to_terminated_archState term ∘ fst);
+      if fstate is Some fs then mret (Some fs)
       else
-        (* Check if termination condition met. If not, execute non-eager step *)
-        fstate ← mget to_terminated_archState;
-        if fstate is Some fs then mret fs else run_to_term_eager_normal fuel
-    else mthrow "Out of fuel"
+        initial ← mget snd;
+        if (initial : bool) then
+          Exec.liftSt fst $ run_eager_all term fuel;;
+          msetv snd false;;
+          mret None
+        else
+          Exec.liftSt fst $ run_normal_then_eager term fuel;;
+          mret None
+    in
+    opModel.Make threads (mstate * bool) init step.
 
-  with run_to_term_eager_eager (fuel : nat) (tid : fin threads)  :
-      Exec.t mstate string {s : archState threads & archState.is_terminated term s} :=
-    if fuel is S fuel then
-      (* Try to do eager execution of thread [tid] if possible *)
-      '(instr_ran : bool) ← run_eager_thread_step tid;
-      if instr_ran then
-        (* If we run an eager transition, run another one *)
-        run_to_term_eager_eager fuel tid
-      else
-        (* Otherwise, check if termination condition met. If not, execute
-            non-eager step *)
-        fstate ← mget to_terminated_archState;
-        if fstate is Some fs then mret fs else run_to_term_eager_normal fuel
-    else mthrow "Out of fuel".
-
-
-  (** ** Full model runner *)
-
-  Definition run_to_term (allow_eager : bool) (fuel : nat) :
-        Exec.t mstate string
-        {s : archState threads & archState.is_terminated term s} :=
-    (* If eager transitions allowed, try to eagerly execute each thread,
-        as we are in the first iteration *)
-    if allow_eager then
-      run_eager_all fuel;;
-      fstate ← mget to_terminated_archState;
-      if fstate is Some fs then mret fs else run_to_term_eager_normal fuel
-    else
-      run_to_term_no_eager fuel.
 End Model.
 Arguments mstate : clear implicits.
-
+Arguments x86_tso_opmodel : clear implicits.
+Arguments x86_tso_opmodel_eager : clear implicits.
 
 (** Top-level one-threaded model function that takes fuel (guaranteed
     termination) and an instruction monad, and returns a computational set of
     all possible final states. *)
-Definition x86_operational_modelc (fuel : nat) (isem : iMon ()) (allow_eager : bool)
+Definition x86_tso_modelc (fuel : nat) (isem : iMon ()) (allow_eager : bool)
   : (archModel.c ∅) :=
-  λ n term (initSt: archState n),
-    from_archState term initSt
-    |> archModel.Res.from_exec (run_to_term isem term allow_eager fuel).
+  if allow_eager then
+    opModel.to_archModel (λ threads, x86_tso_opmodel_eager threads isem) fuel
+  else
+    opModel.to_archModel (λ threads, x86_tso_opmodel threads isem) fuel.

--- a/ArchSemX86/tests/X86OperationalModelTest.v
+++ b/ArchSemX86/tests/X86OperationalModelTest.v
@@ -137,7 +137,7 @@ Module XOR.
       archState.address_space := () |}.
 
   Definition test_results :=
-    x86_operational_modelc 2 x86_sem false 1%nat termCond initState.
+    x86_tso_modelc 2 x86_sem false 1%nat termCond initState.
 
   Goal reg_extract rax 0%fin <$> test_results = Listset [Ok 0x110%Z].
   Proof.
@@ -146,7 +146,7 @@ Module XOR.
   Qed.
 
   Definition test_results_eager :=
-    x86_operational_modelc 2 x86_sem true 1%nat termCond initState.
+    x86_tso_modelc 2 x86_sem true 1%nat termCond initState.
 
   Goal reg_extract rax 0%fin <$> test_results_eager = Listset [Ok 0x110%Z].
     Proof.
@@ -205,7 +205,7 @@ Module MP.
   Definition fuel := 12%nat.
 
   Definition test_results :=
-    x86_operational_modelc fuel x86_sem false n_threads termCond initState.
+    x86_tso_modelc fuel x86_sem false n_threads termCond initState.
 
   Goal elements (regs_extract [(1%fin, rax); (1%fin, rbx)] <$> test_results) ≡ₚ
     [Ok [0x0%Z;0x0%Z]; Ok [0x0%Z;0x1%Z]; Ok [0x1%Z; 0x1%Z]].
@@ -215,7 +215,7 @@ Module MP.
   Qed.
 
   Definition test_results_eager :=
-    x86_operational_modelc fuel x86_sem true n_threads termCond initState.
+    x86_tso_modelc fuel x86_sem true n_threads termCond initState.
 
   Goal elements (regs_extract [(1%fin, rax); (1%fin, rbx)] <$> test_results) ≡ₚ
     [Ok [0x0%Z;0x0%Z]; Ok [0x0%Z;0x1%Z]; Ok [0x1%Z; 0x1%Z]].
@@ -276,7 +276,7 @@ Module SB.
   Definition fuel := 12%nat.
 
   Definition test_results :=
-    x86_operational_modelc fuel x86_sem false n_threads termCond initState.
+    x86_tso_modelc fuel x86_sem false n_threads termCond initState.
 
   Goal elements (regs_extract [(0%fin, rax); (1%fin, rax)] <$> test_results) ≡ₚ
     [Ok [0x0%Z;0x0%Z]; Ok [0x0%Z;0x1%Z]; Ok [0x1%Z; 0x0%Z]; Ok [0x1%Z; 0x1%Z]].
@@ -286,7 +286,7 @@ Module SB.
   Qed.
 
   Definition test_results_eager :=
-    x86_operational_modelc fuel x86_sem true n_threads termCond initState.
+    x86_tso_modelc fuel x86_sem true n_threads termCond initState.
 
   Goal elements (regs_extract [(0%fin, rax); (1%fin, rax)] <$> test_results_eager) ≡ₚ
     [Ok [0x0%Z;0x0%Z]; Ok [0x0%Z;0x1%Z]; Ok [0x1%Z; 0x0%Z]; Ok [0x1%Z; 0x1%Z]].
@@ -350,7 +350,7 @@ Module R_PO_MFENCE.
     [reg_extract rax 1%fin test_result; mem_extract 0x1200 8 test_result].
 
   Definition test_results :=
-    x86_operational_modelc fuel x86_sem false n_threads termCond initState.
+    x86_tso_modelc fuel x86_sem false n_threads termCond initState.
 
   Goal elements (result_extraction <$> test_results) ≡ₚ
     [[Ok 0x0%Z; Ok 0x1%Z]; [Ok 0x1%Z; Ok 0x1%Z]; [Ok 0x1%Z; Ok 0x2%Z]].
@@ -360,7 +360,7 @@ Module R_PO_MFENCE.
   Qed.
 
   Definition test_results_eager :=
-    x86_operational_modelc fuel x86_sem true n_threads termCond initState.
+    x86_tso_modelc fuel x86_sem true n_threads termCond initState.
 
   Goal elements (result_extraction <$> test_results) ≡ₚ
     [[Ok 0x0%Z; Ok 0x1%Z]; [Ok 0x1%Z; Ok 0x1%Z]; [Ok 0x1%Z; Ok 0x2%Z]].
@@ -440,7 +440,7 @@ Module IRIW.
   (* Non-eager runner is too slow (> 10s), we're not running it here *)
 
   Definition test_results :=
-    x86_operational_modelc fuel x86_sem true n_threads termCond initState.
+    x86_tso_modelc fuel x86_sem true n_threads termCond initState.
 
   Goal elements (regs_extract [(1%fin, rax); (1%fin, rbx); (3%fin, rax); (3%fin, rbx)] <$> test_results) ≡ₚ
     [Ok [0x0%Z; 0x0%Z; 0x0%Z; 0x0%Z]; Ok [0x0%Z; 0x0%Z; 0x0%Z; 0x1%Z]; Ok [0x0%Z; 0x0%Z; 0x1%Z; 0x0%Z]; Ok [0x0%Z; 0x0%Z; 0x1%Z; 0x1%Z];
@@ -517,7 +517,7 @@ Module SB_mixed.
   (* Non-eager runner is too slow (> 10s), we're not running it here *)
 
   Definition test_results_eager :=
-    x86_operational_modelc fuel x86_sem true n_threads termCond initState.
+    x86_tso_modelc fuel x86_sem true n_threads termCond initState.
 
   Goal elements (regs_extract [(0%fin, rcx); (1%fin, rcx); (0%fin, rsi); (1%fin, rsi)] <$> test_results_eager) ≡ₚ
     [Ok [0x200000002%Z; 0x100000001%Z; 0x0%Z; 0x0%Z]; 

--- a/Extraction/ArmInstExtr.v
+++ b/Extraction/ArmInstExtr.v
@@ -55,4 +55,4 @@ Set Extraction Output Directory ".".
 #[warnings="-extraction-remaining-implicit,-extraction-reserved-identifier"]
 Separate Extraction
   Arm sail_tiny_arm_sem UMPromising_pf VMPromising_pf
-  X86Inst.X86 sail_tiny_x86_sem x86_operational_modelc.
+  X86Inst.X86 sail_tiny_x86_sem x86_tso_modelc.

--- a/Extraction/archsem.ml
+++ b/Extraction/archsem.ml
@@ -93,7 +93,7 @@ module X86 = struct
     tc rm
 
   let op_model ?(allow_eager = true) isem fuel term initState =
-    OperationalX86TSO.x86_operational_modelc (Z.of_int fuel) isem allow_eager
+    OperationalX86TSO.x86_tso_modelc (Z.of_int fuel) isem allow_eager
       (ArchState.num_thread initState |> Z.of_int)
       (termCond_to_coq term) initState
     |> Obj.magic


### PR DESCRIPTION
<!-- start jj-vine stack -->
This PR is part of a stack containing 3 PRs:

1. `main`
2. #217
3. **"refactor(x86-TSO): Convert x86-TSO to opmodel setup" (this PR)**
4. #219
<!-- end jj-vine stack -->