### PR TITLE
refactor(Isla): Rename field in cli's Isla.Ir.thread from init to regs

### DIFF
--- a/cli/lib/isla/converter.ml
+++ b/cli/lib/isla/converter.ml
@@ -199,7 +199,7 @@ let build_registers
          in
          (reg, normalize_register_gen ~arch ~context reg gen)
        )
-      thread.init
+      thread.regs
   in
   let base_regs = pc_entry :: used_regs in
   let has regs name = List.exists (fun (reg, _) -> reg = name) regs in

--- a/cli/lib/isla/ir.ml
+++ b/cli/lib/isla/ir.ml
@@ -50,7 +50,7 @@ module Toml = Litmus.Toml
 type thread =
   { tid : int;
     code : string;
-    init : (string * Term.t) list (* TODO: Add extra breakpoints *)
+    regs : (string * Term.t) list (* TODO: Add extra breakpoints *)
   }
 
 type section =
@@ -117,8 +117,8 @@ let parse_thread (tid, table) =
          Toml.error "register %s is defined in both init and reset" k
      )
     reset;
-  let merged = init @ reset in
-  {tid; code; init = merged}
+  let regs = init @ reset in
+  {tid; code; regs}
 
 let parse_threads toml =
   let table = Toml.get_table toml in

--- a/cli/lib/isla/normalize.ml
+++ b/cli/lib/isla/normalize.ml
@@ -45,10 +45,10 @@ module Config = Litmus.Config
 
 let normalize_thread (thread : Ir.thread) =
   { thread with
-    init =
+    regs =
       List.map
         (fun (reg, value) -> (Config.get_reg_rename_or reg, value))
-        thread.init
+        thread.regs
   }
 
 let apply (ir : Ir.t) : Ir.t =


### PR DESCRIPTION
<!-- start jj-vine stack -->
This PR is part of a stack containing 2 PRs:

1. `main`
2. **"refactor(Isla): Rename field in cli's Isla.Ir.thread from init to regs" (this PR)**
3. #223
<!-- end jj-vine stack -->