### PR TITLE
refactor: Make the CLI run operational models directly

### DIFF
--- a/ArchSemArm/UMPromising.v
+++ b/ArchSemArm/UMPromising.v
@@ -609,3 +609,9 @@ Definition UMPromising_cert :=
 Definition UMPromising_exe := Promising_to_Modelc UMPromising.
 
 Definition UMPromising_pf := Promising_to_Modelc_pf UMPromising.
+
+Definition UMPromising_opmodel (isem : iMon ()) (n : nat) : opModel n :=
+  CPState.opmodel isem UMPromising.
+
+Definition UMPromising_opmodel_pf (isem : iMon ()) (n : nat) : opModel n :=
+  CPState.opmodel_pf isem UMPromising.

--- a/ArchSemArm/VMPromising.v
+++ b/ArchSemArm/VMPromising.v
@@ -2790,3 +2790,9 @@ Definition VMPromising_exe (bbm_param : BBM.param) :=
 
 Definition VMPromising_pf (bbm_param : BBM.param) :=
   Promising_to_Modelc_pf (VMPromising bbm_param).
+
+Definition VMPromising_opmodel (bbm_param : BBM.param) (isem : iMon ())
+    (n : nat) : opModel n := CPState.opmodel isem (VMPromising bbm_param).
+
+Definition VMPromising_opmodel_pf (bbm_param : BBM.param) (isem : iMon ())
+    (n : nat) : opModel n := CPState.opmodel_pf isem (VMPromising bbm_param).

--- a/Extraction/ArmInstExtr.v
+++ b/Extraction/ArmInstExtr.v
@@ -54,5 +54,5 @@ Set Extraction Output Directory ".".
 
 #[warnings="-extraction-remaining-implicit,-extraction-reserved-identifier"]
 Separate Extraction
-  Arm sail_tiny_arm_sem UMPromising_pf VMPromising_pf
-  X86Inst.X86 sail_tiny_x86_sem x86_tso_modelc.
+  Arm sail_tiny_arm_sem UMPromising_opmodel_pf VMPromising_opmodel_pf
+  X86Inst.X86 sail_tiny_x86_sem x86_tso_opmodel x86_tso_opmodel_eager.

--- a/Extraction/arch.mli
+++ b/Extraction/arch.mli
@@ -130,6 +130,8 @@ module type Arch = sig
 
     val reg : int -> t -> RegMap.t
 
+    val num_thread : t -> int
+
     val mem : t -> MemMap.t
   end
 
@@ -149,5 +151,46 @@ module type Arch = sig
     type 'a t = iSem -> (* fuel *) int -> termCond -> ArchState.t -> 'a Res.t list
   end
 
-  val seq_model : Utils.empty ArchModel.t
+  (** Operational models, that can be driven one transition at a time from
+      OCaml. This is the OCaml view of [TermModels.opModel] *)
+  module OpModel : sig
+    (** The possible outcomes of a single non-deterministic transition, split by
+        kind. ['st] is the internal state of the model *)
+    type 'st step_result =
+      { next : 'st list;  (** non-final transitions *)
+        finals : ('st * ArchState.t) list;  (** terminating transitions *)
+        errors : ('st * string) list
+      }
+
+    module type S = sig
+      (** Model-specific configuration, e.g. break-before-make mode *)
+      type config
+
+      val default_config : config
+
+      (** A model instantiated for a fixed number of threads *)
+      type t
+
+      val make : config -> iSem -> nth:int -> t
+
+      (** The internal state of the model *)
+      type state
+
+      val init : t -> termCond -> ArchState.t -> state
+
+      (** [step model term initSt ~fuel st] takes one transition from [st].
+          [initSt] is the initial architectural state and [fuel] the amount of
+          fuel left, both of which some models use internally *)
+      val step :
+         t ->
+        termCond ->
+        ArchState.t ->
+        fuel:int ->
+        state ->
+        state step_result
+    end
+  end
+
+  (** The sequential model, only supports a single thread *)
+  module Seq : OpModel.S with type config = unit
 end

--- a/Extraction/archBuild.ml
+++ b/Extraction/archBuild.ml
@@ -200,17 +200,88 @@ module Build (ArchReq : ArchRequired) = struct
     type 'a t = iSem -> (* fuel *) int -> termCond -> ArchState.t -> 'a Res.t list
   end
 
-  let seq_model isem fuel term initState =
-    let termCond_coq tid rm =
-      let tc = List.nth term (Z.to_int tid) in
-      tc rm
-    in
-    if List.length term != 1 then
-      raise
-        (Failure
-           "termination condition list must be of size 1 for sequential model"
-        );
-    SeqModel.sequential_modelc None (Z.of_int fuel) isem (Z.of_int 1) termCond_coq
-      initState
-    |> Obj.magic
+  module OpModel = struct
+    type 'st step_result =
+      { next : 'st list;
+        finals : ('st * ArchState.t) list;
+        errors : ('st * string) list
+      }
+
+    module type S = sig
+      type config
+
+      val default_config : config
+
+      type t
+
+      val make : config -> iSem -> nth:int -> t
+
+      type state
+
+      val init : t -> termCond -> ArchState.t -> state
+
+      val step :
+         t ->
+        termCond ->
+        ArchState.t ->
+        fuel:int ->
+        state ->
+        state step_result
+    end
+
+    (** Wrap an extracted [TermModels.opModel] into an [S] module. The model is
+        built once by [make], for a fixed number of threads *)
+    module Of_coq (P : sig
+        type config
+
+        val default_config : config
+
+        (** May raise [Failure] if [nth] is not supported by the model *)
+        val opmodel : config -> iSem -> nth:int -> TM.Coq_opModel.t
+      end) : S with type config = P.config = struct
+      type config = P.config
+
+      let default_config = P.default_config
+
+      type t = TM.Coq_opModel.t
+
+      let make config isem ~nth = P.opmodel config isem ~nth
+
+      type state = TM.Coq_opModel.state
+
+      let termCond_to_coq (term : termCond) tid rm =
+        let tc = List.nth term (Z.to_int tid) in
+        tc rm
+
+      let init (opmod : t) term initSt =
+        opmod.TM.Coq_opModel.init (termCond_to_coq term) initSt
+
+      let step (opmod : t) term initSt ~fuel state =
+        let res =
+          opmod.TM.Coq_opModel.step (termCond_to_coq term) initSt (Z.of_int fuel)
+            state
+        in
+        let (next, finals) =
+          List.partition_map
+            (function
+              | (st, None) -> Either.Left st
+              | (st, Some (Specif.Coq_existT (fs, _))) -> Either.Right (st, fs)
+              )
+            res.Exec.Exec.results
+        in
+        {next; finals; errors = res.Exec.Exec.errors}
+    end
+  end
+
+  module Seq = OpModel.Of_coq (struct
+      type config = unit
+
+      let default_config = ()
+
+      let opmodel () isem ~nth =
+        if nth <> 1 then
+          Printf.ksprintf failwith
+            "The sequential model only supports one thread, got %d" nth;
+        SeqModel.sequential_opmodel None isem
+    end)
 end

--- a/Extraction/archsem.mli
+++ b/Extraction/archsem.mli
@@ -50,7 +50,8 @@ module Arm : sig
 
   val tiny_isa : iSem
 
-  val umProm_model : empty ArchModel.t
+  (** The user-mode promising model, with the promise-first optimisation *)
+  module UMProm : OpModel.S with type config = unit
 
   module BBM : sig
     type param =
@@ -59,7 +60,9 @@ module Arm : sig
       | Strict
   end
 
-  val vmProm_model : ?bbm_param:BBM.param -> empty ArchModel.t
+  (** The virtual-memory promising model, with the promise-first optimisation.
+      Its config is the break-before-make mode *)
+  module VMProm : OpModel.S with type config = BBM.param
 end
 
 module X86 : sig
@@ -67,5 +70,7 @@ module X86 : sig
 
   val tiny_isa : iSem
 
-  val op_model : ?allow_eager:bool -> empty ArchModel.t
+  (** The X86-TSO operational model. Its config says whether eager transitions
+      are allowed *)
+  module Tso : OpModel.S with type config = bool
 end

--- a/cli/bin/main.ml
+++ b/cli/bin/main.ml
@@ -51,6 +51,13 @@ open Litmus
 module ArmRunner = Runner.Make (Arm)
 module X86Runner = Runner.Make (X86)
 
+(* Drivers for each operational model *)
+module ArmSeq = Driver.Make (Arm) (Arm.Seq)
+module ArmUmp = Driver.Make (Arm) (Arm.UMProm)
+module ArmVmp = Driver.Make (Arm) (Arm.VMProm)
+module X86Seq = Driver.Make (X86) (X86.Seq)
+module X86Tso = Driver.Make (X86) (X86.Tso)
+
 (** {1 Running litmus tests} *)
 
 (** {2 Running litmus tests utilities} *)
@@ -219,11 +226,11 @@ let cmd_seq =
     match Config.get_arch () with
     | Arm ->
         run_tests "arm-seq"
-          (ArmRunner.run_test_file ~parse Arm.(seq_model tiny_isa))
+          (ArmRunner.run_test_file ~parse (ArmSeq.model Arm.tiny_isa))
           files
     | X86 ->
         run_tests "x86-seq"
-          (X86Runner.run_test_file ~parse X86.(seq_model tiny_isa))
+          (X86Runner.run_test_file ~parse (X86Seq.model X86.tiny_isa))
           files
   in
   let info =
@@ -239,7 +246,7 @@ let cmd_ump =
     let parse = parse_testfile fmt in
     assert (Config.get_arch () = Arch_id.Arm);
     run_tests "ump"
-      (ArmRunner.run_test_file ~parse Arm.(umProm_model tiny_isa))
+      (ArmRunner.run_test_file ~parse (ArmUmp.model Arm.tiny_isa))
       files
   in
   let info =
@@ -282,7 +289,7 @@ let cmd_vmp =
     let parse = parse_testfile fmt in
     assert (Config.get_arch () = Arch_id.Arm);
     run_tests "vmp"
-      (ArmRunner.run_test_file ~parse (vmProm_model ~bbm_param tiny_isa))
+      (ArmRunner.run_test_file ~parse (ArmVmp.model ~config:bbm_param tiny_isa))
       files
   in
   let info =
@@ -308,7 +315,9 @@ let cmd_tso =
     let parse = parse_testfile fmt in
     assert (Config.get_arch () = Arch_id.X86);
     run_tests "tso"
-      (X86Runner.run_test_file ~parse X86.(op_model ~allow_eager tiny_isa))
+      (X86Runner.run_test_file ~parse
+         (X86Tso.model ~config:allow_eager X86.tiny_isa)
+      )
       files
   in
   let info =

--- a/cli/lib/litmus/driver.ml
+++ b/cli/lib/litmus/driver.ml
@@ -38,67 +38,38 @@
 (*                                                                            *)
 (******************************************************************************)
 
-module RegValGen = RegValGen
-module Utils = Utils
+(** Drive an operational model from OCaml.
 
-module type Arch = Arch.Arch
+    This is the OCaml counterpart of [TermModels.opModel.run] in
+    [ArchSem/TermModels.v]: instead of letting Rocq run the model, the
+    transition tree is explored here, which gives OCaml access to every
+    individual step. *)
 
-type empty = Utils.empty
+module Make (A : Archsem.Arch) (M : A.OpModel.S) = struct
+  (** Explore the model exhaustively and return all the final states, as well as
+      the errors of the branches that failed or ran out of fuel.
 
-module Arm = struct
-  module Required = struct
-    module Arch = ArmInst.Arch
-    include ArmInst.Arm
-
-    let default_address_space = System_types.PAS_NonSecure
-  end
-
-  include ArchBuild.Build (Required)
-
-  let tiny_isa = ArmInst.sail_tiny_arm_sem true
-
-  module UMProm = OpModel.Of_coq (struct
-      type config = unit
-
-      let default_config = ()
-
-      let opmodel () isem ~nth =
-        UMPromising.coq_UMPromising_opmodel_pf isem (Z.of_int nth)
-    end)
-
-  module BBM = VMPromising.BBM
-
-  module VMProm = OpModel.Of_coq (struct
-      type config = BBM.param
-
-      let default_config = BBM.Off
-
-      let opmodel bbm_param isem ~nth =
-        VMPromising.coq_VMPromising_opmodel_pf bbm_param isem (Z.of_int nth)
-    end)
-end
-
-module X86 = struct
-  module Required = struct
-    module Arch = X86Inst.Arch
-    include X86Inst.X86
-
-    let default_address_space = ()
-  end
-
-  include ArchBuild.Build (Required)
-
-  let tiny_isa = X86Inst.sail_tiny_x86_sem true
-
-  module Tso = OpModel.Of_coq (struct
-      (** Whether eager transitions are allowed *)
-      type config = bool
-
-      let default_config = true
-
-      let opmodel allow_eager isem ~nth =
-        let nth = Z.of_int nth in
-        if allow_eager then OperationalX86TSO.x86_tso_opmodel_eager nth isem
-        else OperationalX86TSO.x86_tso_opmodel nth isem
-    end)
+      The exploration uses an explicit stack instead of the native one, so that
+      all the calls to [M.step] happen at the same native stack depth, which
+      merges the exploration paths when profiling. *)
+  let model ?(config = M.default_config) isem fuel term initSt =
+    let m = M.make config isem ~nth:(A.ArchState.num_thread initSt) in
+    (* [finals] and [errors] are accumulated in reverse order *)
+    let rec loop finals errors = function
+      | [] -> (finals, errors)
+      | (_, 0) :: rest -> loop finals ("Out of fuel" :: errors) rest
+      | (st, fuel) :: rest ->
+          let {A.OpModel.next; finals = fs; errors = errs} =
+            M.step m term initSt ~fuel st
+          in
+          let finals = List.fold_left (fun acc (_, f) -> f :: acc) finals fs in
+          let errors = List.fold_left (fun acc (_, e) -> e :: acc) errors errs in
+          let rest =
+            List.fold_left (fun acc st -> (st, fuel - 1) :: acc) rest next
+          in
+          loop finals errors rest
+    in
+    let (finals, errors) = loop [] [] [(M.init m term initSt, fuel)] in
+    List.rev_map (fun fs -> A.ArchModel.Res.FinalState fs) finals
+    @ List.rev_map (fun e -> A.ArchModel.Res.Error e) errors
 end


### PR DESCRIPTION
That means OCaml now drives the operational model directly
This allows:
- To avoid stack overflow due to recursion depth
- To later implement other runners that are interactive
  or do some kind of tracing
- To ease profiling by having each step of the model starting 
  from the same stackframe