### PR TITLE
feat(Isla): Support bounded address allocation

### DIFF
--- a/cli/lib/isla/allocator.ml
+++ b/cli/lib/isla/allocator.ml
@@ -40,7 +40,12 @@
 
 (** Page-oriented address allocator. *)
 
-type t = {mutable current : int}
+module Error = Litmus.Error
+
+type t =
+  { mutable current : int;
+    limit : int option
+  }
 
 let default_base = 0x1000
 
@@ -49,24 +54,32 @@ let page_size = 0x1000
 let big_size = 1 lsl 21
 
 let align_up addr alignment =
-  if alignment <= 0 then
-    Litmus.Error.fatal "allocator: alignment must be positive";
+  if alignment <= 0 then Error.fatal "allocator: alignment must be positive";
   let rem = addr mod alignment in
   if rem = 0 then addr else addr + alignment - rem
 
 let page_after addr = align_up (addr + 1) page_size
 
-let make ?(base = default_base) ?(reserved = []) () =
+let make ?(base = default_base) ?limit ?(reserved = []) () =
   let current =
     List.fold_left
       (fun current addr -> max current (page_after addr))
       base reserved
   in
-  {current}
+  ( match limit with
+  | Some limit when current > limit ->
+      Error.failwith "allocator: initial address exceeds limit"
+  | _ -> ()
+  );
+  {current; limit}
 
 let alloc_aligned allocator ~size ~alignment =
   let addr = align_up allocator.current alignment in
-  allocator.current <- addr + size;
+  let next = addr + size in
+  ( match allocator.limit with
+  | Some limit when next > limit -> Error.failwith "allocator: limit exceeded"
+  | _ -> allocator.current <- next
+  );
   addr
 
 let alloc_page allocator =

--- a/cli/lib/isla/allocator.mli
+++ b/cli/lib/isla/allocator.mli
@@ -48,9 +48,9 @@ val page_size : int
 (** Size of one block (2MB) allocated by [alloc_big]. *)
 val big_size : int
 
-(** Make an allocator, optionally with reserved addresses. Each reserved
-    address blocks the page containing it. *)
-val make : ?base:int -> ?reserved:int list -> unit -> t
+(** Make an allocator, optionally with an exclusive upper limit and reserved
+    addresses. Each reserved address blocks the page containing it. *)
+val make : ?base:int -> ?limit:int -> ?reserved:int list -> unit -> t
 
 (** Allocate [size] bytes at an address aligned to [alignment]. *)
 val alloc_aligned : t -> size:int -> alignment:int -> int


### PR DESCRIPTION
Add an optional exclusive limit to the existing allocator so callers can partition independently allocated arenas.