### PR TITLE
feat(Isla): Support default page-table option

### DIFF
--- a/cli/lib/isla/converter.ml
+++ b/cli/lib/isla/converter.ml
@@ -350,10 +350,14 @@ let build_lookup_addr asm_result page_table =
     match page_table with
     | None -> []
     | Some layout ->
-        ("page_table_base", layout.Page_table_builder.root)
-        :: (layout.Page_table_builder.table_symbols_pa
-          @ layout.Page_table_builder.data_symbols_pa
-           )
+        let default_root =
+          Option.map
+            (fun root -> ("page_table_base", root))
+            layout.Page_table_builder.default_root
+          |> Option.to_list
+        in
+        default_root @ layout.Page_table_builder.table_symbols_pa
+        @ layout.Page_table_builder.data_symbols_pa
   in
   let symbols_addr = asm_result.Assembler.symbols @ page_table_symbols in
   fun name ->
@@ -506,7 +510,7 @@ let to_testrepr ~filename (ir : Ir.t) : Testrepr.t =
   in
   let lookup_addr = build_lookup_addr asm_result page_table in
   let page_table_root =
-    Option.map (fun layout -> layout.Page_table_builder.root) page_table
+    Option.bind page_table (fun layout -> layout.Page_table_builder.default_root)
   in
   let threads =
     build_threads ~arch:ir.arch ?page_table_entries ?page_table_root ~lookup_addr

--- a/cli/lib/isla/lexer.mll
+++ b/cli/lib/isla/lexer.mll
@@ -71,6 +71,7 @@ rule token = parse
   | ',' { COMMA }
   | '-' { MINUS }
   | "aligned" { ALIGNED }
+  | "option" { OPTION }
   | "virtual" { VIRTUAL }
   | "physical" { PHYSICAL }
   | "identity" { IDENTITY }

--- a/cli/lib/isla/page_table/page_table_ast.ml
+++ b/cli/lib/isla/page_table/page_table_ast.ml
@@ -63,6 +63,8 @@ type mapping_target =
   | Table of Z.t
 
 type stmt =
+  (* Controls whether an implicit unnamed Stage-1 root is built. *)
+  | OptionDefaultTables of bool
   (* [virtual x y;] predeclares virtual-address names. *)
   | Virtual of string list
   (* [physical pa_x pa_y;] predeclares physical-address names. *)

--- a/cli/lib/isla/page_table/page_table_builder.ml
+++ b/cli/lib/isla/page_table/page_table_builder.ml
@@ -51,7 +51,7 @@ type descriptor = int64
 type data_value = Z.t
 
 type layout =
-  { root : pa;
+  { default_root : pa option;
     table_entries : (pa * descriptor) list;
     table_symbols_pa : (string * pa) list;
     data_symbols_pa : (string * pa) list;
@@ -74,7 +74,7 @@ type t =
     table_allocator : Allocator.t;
     (* Default root translation-table used when statements are not nested in a
        named table block. *)
-    default_root : table_root;
+    default_root : table_root option;
     (* Named translation-table roots. *)
     mutable named_roots : table_root list;
     (* Page-table descriptors, keyed by their physical addresses. *)
@@ -87,8 +87,8 @@ type t =
     mutable data_inits : (pa * data_value) list
   }
 
-let make ~symbol_allocator ~table_allocator ~pa_alignments ~root =
-  let default_root = {name = None; base = root} in
+let make ~symbol_allocator ~table_allocator ~pa_alignments ~default_root =
+  let default_root = Option.map (fun base -> {name = None; base}) default_root in
   { symbol_allocator;
     table_allocator;
     default_root;
@@ -292,6 +292,12 @@ let pa_alignment_requests stmts =
      )
     [] requests
 
+let default_tables_enabled stmts =
+  List.find_map
+    (function Page_table_ast.OptionDefaultTables value -> Some value | _ -> None)
+    stmts
+  |> Option.value ~default:true
+
 let eval_mapping_target ?level ?(attrs = []) builder ~root ~va = function
   | Page_table_ast.PaName pa_name ->
       let alignment = Option.map mapping_alignment level in
@@ -312,11 +318,20 @@ let eval_mapping_target ?level ?(attrs = []) builder ~root ~va = function
       in
       write_descriptor ~level builder ~root ~va desc
 
+let require_root = function
+  | Some root -> root
+  | None ->
+      error
+        "page_table: top-level mapping requires an implicit default table, but \
+         default_tables = false"
+
 let rec eval_stmt builder ~symbolic_vas ~table_block ~root = function
+  | Page_table_ast.OptionDefaultTables _ -> ()
   | Page_table_ast.Virtual _ -> ()
   | Page_table_ast.Physical _ -> ()
   | Page_table_ast.AlignedVirtual _ -> ()
   | Page_table_ast.Mapping {va_name; target; attrs; level} ->
+      let root = require_root root in
       let va =
         match List.assoc_opt va_name symbolic_vas with
         | Some addr -> addr
@@ -333,6 +348,7 @@ let rec eval_stmt builder ~symbolic_vas ~table_block ~root = function
         error "page_table: identity code address 0x%x is outside the code arena"
           addr
   | Page_table_ast.IdentityMapping {addr; attr = Page_table_ast.Data} ->
+      let root = require_root root in
       let addr = addr_of_z "address" addr in
       add_mapping builder ~root ~va:addr ~pa:addr Page_table_ast.Data
   | Page_table_ast.TableBlock {name; base; body; _} ->
@@ -340,13 +356,15 @@ let rec eval_stmt builder ~symbolic_vas ~table_block ~root = function
       if List.exists (fun root -> root.name = Some name) builder.named_roots then
         error "page_table: duplicate table root: %s" name;
       if
-        builder.default_root.base = base
+        Option.map (fun root -> root.base) builder.default_root = Some base
         || List.exists (fun root -> root.base = base) builder.named_roots
       then error "page_table: duplicate table base: 0x%x" base;
       let root = {name = Some name; base} in
       builder.named_roots <- root :: builder.named_roots;
       initialise_root builder ~table_block root;
-      List.iter (eval_stmt builder ~symbolic_vas ~table_block ~root) body
+      List.iter
+        (eval_stmt builder ~symbolic_vas ~table_block ~root:(Some root))
+        body
 
 (** {1 Layout construction} *)
 
@@ -359,7 +377,7 @@ let to_entries builder =
 
 (** Freeze the builder state into the immutable layout used downstream. *)
 let to_layout builder =
-  let root = builder.default_root.base in
+  let default_root = Option.map (fun root -> root.base) builder.default_root in
   let table_entries = to_entries builder in
   let table_symbols_pa =
     List.filter_map
@@ -369,7 +387,7 @@ let to_layout builder =
   in
   let data_symbols_pa = List.rev builder.data_symbols_pa in
   let data_inits = builder.data_inits in
-  {root; table_entries; table_symbols_pa; data_symbols_pa; data_inits}
+  {default_root; table_entries; table_symbols_pa; data_symbols_pa; data_inits}
 
 let build
       ~arch
@@ -381,16 +399,20 @@ let build
   =
   check_arch arch;
   if stmts = [] then error "page_table: empty page_table_setup";
-  let root =
-    try Allocator.alloc_page table_allocator
-    with Failure msg -> error "page_table: %s" msg
+  let default_root =
+    if default_tables_enabled stmts then
+      Some
+        ( try Allocator.alloc_page table_allocator
+          with Failure msg -> error "page_table: %s" msg
+        )
+    else None
   in
   let builder =
     make ~symbol_allocator ~table_allocator
       ~pa_alignments:(pa_alignment_requests stmts)
-      ~root
+      ~default_root
   in
-  initialise_root builder ~table_block builder.default_root;
+  Option.iter (initialise_root builder ~table_block) builder.default_root;
   (* Evaluate each statement, using symbolic VAs to resolve virtual names. *)
   List.iter
     (eval_stmt builder ~symbolic_vas ~table_block ~root:builder.default_root)

--- a/cli/lib/isla/page_table/page_table_builder.mli
+++ b/cli/lib/isla/page_table/page_table_builder.mli
@@ -52,7 +52,8 @@ type descriptor = int64
 type data_value = Z.t
 
 type layout =
-  { root : pa;
+  { (* Implicit unnamed Stage-1 root, absent when [default_tables = false]. *)
+    default_root : pa option;
     table_entries : (pa * descriptor) list;
     (* Named table roots and their physical addresses. *)
     table_symbols_pa : (string * pa) list;

--- a/cli/lib/isla/parser.mly
+++ b/cli/lib/isla/parser.mly
@@ -61,6 +61,7 @@
 %token RBRACE "}"
 %token MAPS_TO "|->"
 %token MAYBE_MAPS_TO "?->"
+%token OPTION
 %token ALIGNED
 %token VIRTUAL
 %token PHYSICAL
@@ -93,6 +94,7 @@
 %type <Page_table_ast.mapping_target> page_table_mapping_target
 %type <Page_table_ast.attr> page_table_attr
 %type <Page_table_ast.descriptor_field list> page_table_descriptor_attrs
+%type <bool> page_table_bool
 %type <int> page_table_mapping_level
 %type <Page_table_ast.table_stage> page_table_stage
 %type <string> kw_name
@@ -113,6 +115,11 @@ page_table_stmt:
   | b = page_table_block; option(";") { b }
 
 page_table_stmt_inner:
+  | OPTION; name = IDENT; "="; value = page_table_bool
+    { if name <> "default_tables" then
+        failwith ("unsupported page-table option: " ^ name);
+      Page_table_ast.OptionDefaultTables value
+    }
   | VIRTUAL; names = nonempty_list(IDENT)
     { Page_table_ast.Virtual names }
   | PHYSICAL; names = nonempty_list(IDENT)
@@ -172,6 +179,10 @@ page_table_mapping_level:
     { try Z.to_int level
       with Z.Overflow -> failwith "page-table level is out of range"
     }
+
+page_table_bool:
+  | TRUE { true }
+  | FALSE { false }
 
 prop:
   | e1 = prop; "|"; e2 = prop { Or [e1; e2] }

--- a/cli/tests/arm/vm/SwitchTTBR+VM.litmus.toml
+++ b/cli/tests/arm/vm/SwitchTTBR+VM.litmus.toml
@@ -3,6 +3,7 @@ name = "SwitchTTBR+VM"
 symbolic = ["x"]
 
 page_table_setup = """
+option default_tables = false;
 physical pa0 pa1;
 *pa0 = 0;
 *pa1 = 1;

--- a/cli/tests/converter/expect/arm/vm/SwitchTTBR+VM.litmus.toml
+++ b/cli/tests/converter/expect/arm/vm/SwitchTTBR+VM.litmus.toml
@@ -12,13 +12,13 @@ name = "SwitchTTBR+VM"
   kind = "pagetable"
   addr = 0x2c0000
   step = 8
-  data = 0x304003
+  data = 0x301003
 
 [[memory]]
   kind = "pagetable"
   addr = 0x300000
   step = 8
-  data = 0x307003
+  data = 0x304003
 
 [[memory]]
   kind = "pagetable"
@@ -30,19 +30,25 @@ name = "SwitchTTBR+VM"
   kind = "pagetable"
   addr = 0x302000
   step = 8
+  data = 0x4c1
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x302008
+  step = 8
+  data = 0x200441
+
+[[memory]]
+  kind = "pagetable"
+  addr = 0x302010
+  step = 8
   data = 0x303003
 
 [[memory]]
   kind = "pagetable"
   addr = 0x303000
   step = 8
-  data = 0x4c1
-
-[[memory]]
-  kind = "pagetable"
-  addr = 0x303008
-  step = 8
-  data = 0x200441
+  data = 0x401443
 
 [[memory]]
   kind = "pagetable"
@@ -71,36 +77,6 @@ name = "SwitchTTBR+VM"
 [[memory]]
   kind = "pagetable"
   addr = 0x306000
-  step = 8
-  data = 0x401443
-
-[[memory]]
-  kind = "pagetable"
-  addr = 0x307000
-  step = 8
-  data = 0x308003
-
-[[memory]]
-  kind = "pagetable"
-  addr = 0x308000
-  step = 8
-  data = 0x4c1
-
-[[memory]]
-  kind = "pagetable"
-  addr = 0x308008
-  step = 8
-  data = 0x200441
-
-[[memory]]
-  kind = "pagetable"
-  addr = 0x308010
-  step = 8
-  data = 0x309003
-
-[[memory]]
-  kind = "pagetable"
-  addr = 0x309000
   step = 8
   data = 0x402443
 


### PR DESCRIPTION
- Parse both default_tables values. When disabled, omit the implicit root, page_table_base symbol, and automatic TTBR0_EL1 initialization while continuing to build named roots.